### PR TITLE
Fix Pydantic compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@
 - Run `python -m py_compile $(git ls-files '*.py')` before committing to catch syntax errors.
 - Keep commit messages short and descriptive.
 - Update `README.md` when adding new commands or major functionality.
+- Pin package versions in `requirements.txt` when compatibility issues arise.
+- When resolving an item from `BUGS.md`, document the fix in `FIXED_BUGS.md`.

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,5 +1,4 @@
 # Known Issues
 
-1. **Pydantic compatibility** - `config.py` relies on `BaseSettings` from Pydantic v1. Installing Pydantic v2 raises `PydanticImportError`. Pin `pydantic<2` or update the code.
-2. **Missing packages** - `fastapi` and `uvicorn` are required to run the API but are not listed in `requirements.txt`.
-3. **Vault directory** - `parse_projects.py` expects a `vault/Projects` folder. If the directory does not exist the script fails.
+1. **Missing packages** - `fastapi` and `uvicorn` are required to run the API but are not listed in `requirements.txt`.
+2. **Vault directory** - `parse_projects.py` expects a `vault/Projects` folder. If the directory does not exist the script fails.

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -1,0 +1,3 @@
+# Fixed Bugs
+
+1. **Pydantic compatibility** - `config.py` relies on `BaseSettings` from Pydantic v1. `requirements.txt` now pins `pydantic<2` to avoid import errors with v2.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
    pip install -r requirements.txt
    pip install fastapi uvicorn
    ```
-   The code expects Pydantic v1. If Pydantic v2 is installed add `pydantic<2` to the requirements.
+   `pydantic<2` is pinned in `requirements.txt` to ensure compatibility with Pydantic v1.
 3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `vault/Projects`.
 4. Ensure the vault directory exists and contains markdown project files.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv
-pydantic
+pydantic<2
 pyyaml


### PR DESCRIPTION
## Summary
- pin `pydantic<2` in requirements
- document version pin in the README
- move the Pydantic bug to `FIXED_BUGS.md`
- update AGENTS guidelines

## Testing
- `python -m py_compile config.py main.py parse_projects.py routes/projects.py`

------
https://chatgpt.com/codex/tasks/task_e_68863d03eae48332ba4dd8a8feaf5c49