### PR TITLE
Implement energy tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ uvicorn main:app --reload
 ```
 The service runs on `http://localhost:8000` by default.
 
+Record today's energy and mood from the command line:
+```bash
+python record_energy.py 7 8
+```
+
 ## Roadmap
 See [Mindloom Roadmap.md](Mindloom%20Roadmap.md) for planned phases and upcoming features.
 

--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     # === Paths ===
     VAULT_PATH: Path = Field(PROJECT_ROOT / "vault/Projects", env="VAULT_PATH")
     OUTPUT_PATH: Path = Field(PROJECT_ROOT / "projects.yaml", env="OUTPUT_PATH")
+    ENERGY_LOG_PATH: Path = Field(PROJECT_ROOT / "energy_log.yaml", env="ENERGY_LOG_PATH")
 
     # === Optional tokens ===
     OPENAI_API_KEY: str = Field(default="", env="OPENAI_API_KEY")

--- a/energy.py
+++ b/energy.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Utilities for recording daily energy and mood."""
+
+from datetime import date
+from pathlib import Path
+from typing import List, Dict
+import yaml
+
+from config import config
+
+ENERGY_LOG_PATH = config.ENERGY_LOG_PATH
+
+
+def read_entries(path: Path = ENERGY_LOG_PATH) -> List[Dict]:
+    """Return all energy entries from the log file."""
+    if not path.exists():
+        return []
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or []
+    return data
+
+
+def record_entry(energy: int, mood: int, path: Path = ENERGY_LOG_PATH) -> Dict:
+    """Append a new energy/mood entry and return it."""
+    entry = {"date": date.today().isoformat(), "energy": energy, "mood": mood}
+    entries = read_entries(path)
+    entries.append(entry)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.dump(entries, handle, allow_unicode=True, sort_keys=False)
+    return entry
+

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 """FastAPI application entrypoint."""
 
 from fastapi import FastAPI
-from routes import projects
+from routes import projects, energy
 
 app = FastAPI()
 app.include_router(projects.router)
+app.include_router(energy.router)

--- a/record_energy.py
+++ b/record_energy.py
@@ -1,0 +1,13 @@
+"""CLI script to record daily energy and mood."""
+
+import argparse
+from energy import record_entry
+
+parser = argparse.ArgumentParser(description="Record today's energy and mood")
+parser.add_argument("energy", type=int, help="Energy level 1-10")
+parser.add_argument("mood", type=int, help="Mood level 1-10")
+
+args = parser.parse_args()
+
+entry = record_entry(args.energy, args.mood)
+print(f"Recorded: {entry}")

--- a/routes/energy.py
+++ b/routes/energy.py
@@ -1,0 +1,27 @@
+"""API routes for recording daily energy and mood."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from energy import read_entries, record_entry
+
+router = APIRouter()
+
+
+class EnergyInput(BaseModel):
+    """Input model for energy submissions."""
+
+    energy: int
+    mood: int
+
+
+@router.post("/energy")
+def add_energy(data: EnergyInput):
+    """Record today's energy and mood."""
+    return record_entry(data.energy, data.mood)
+
+
+@router.get("/energy")
+def get_energy():
+    """Return all recorded energy entries."""
+    return read_entries()


### PR DESCRIPTION
## Summary
- add ENERGY_LOG_PATH config
- implement energy log utilities and CLI
- expose `/energy` API endpoint
- include energy example in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865a5981b08332bf01bdf35c99fc32