### PR TITLE
Add basic web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Parse markdown project files from a configured vault directory.
 - Store project metadata and summaries in `projects.yaml`.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
+- Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Containerized setup using Docker and docker-compose.
 
 ## Setup
@@ -25,6 +26,8 @@ python parse_projects.py
 uvicorn main:app --reload
 ```
 The service runs on `http://localhost:8000` by default.
+
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects and record energy.
 
 Record today's energy and mood from the command line:
 ```bash

--- a/main.py
+++ b/main.py
@@ -1,8 +1,9 @@
 """FastAPI application entrypoint."""
 
 from fastapi import FastAPI
-from routes import projects, energy
+from routes import projects, energy, web
 
 app = FastAPI()
 app.include_router(projects.router)
 app.include_router(energy.router)
+app.include_router(web.router)

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -5,6 +5,8 @@ from typing import Optional
 import yaml
 from fastapi import APIRouter, Query
 
+from parse_projects import parse_all_projects
+
 from config import config
 
 router = APIRouter()
@@ -31,3 +33,12 @@ def get_projects(
         projects = [p for p in projects if p.get("effort") == effort]
 
     return projects
+
+
+@router.post("/parse-projects")
+def parse_projects_endpoint():
+    """Parse vault markdown files and update the projects YAML."""
+    projects = parse_all_projects()
+    with open(PROJECTS_FILE, "w", encoding="utf-8") as f:
+        yaml.dump(projects, f, sort_keys=False, allow_unicode=True)
+    return {"count": len(projects)}

--- a/routes/web.py
+++ b/routes/web.py
@@ -1,0 +1,73 @@
+"""Simple web interface for Mindloom."""
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+INDEX_HTML = """
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Mindloom</title>
+</head>
+<body>
+  <h1>Mindloom Interface</h1>
+  <h2>Parse Projects</h2>
+  <button id=\"parseBtn\">Parse</button>
+  <pre id=\"parseResult\"></pre>
+  <h2>Record Energy</h2>
+  <input type=\"number\" id=\"energy\" placeholder=\"Energy 1-10\">
+  <input type=\"number\" id=\"mood\" placeholder=\"Mood 1-10\">
+  <button id=\"recordBtn\">Record</button>
+  <pre id=\"recordResult\"></pre>
+  <h2>Data</h2>
+  <button id=\"loadProjects\">Load Projects</button>
+  <pre id=\"projects\"></pre>
+  <button id=\"loadEnergy\">Load Energy</button>
+  <pre id=\"energyData\"></pre>
+
+<script>
+const parseBtn = document.getElementById('parseBtn');
+parseBtn.onclick = async () => {
+  const res = await fetch('/parse-projects', {method: 'POST'});
+  const data = await res.json();
+  document.getElementById('parseResult').textContent = JSON.stringify(data);
+};
+
+const recordBtn = document.getElementById('recordBtn');
+recordBtn.onclick = async () => {
+  const payload = {
+    energy: parseInt(document.getElementById('energy').value),
+    mood: parseInt(document.getElementById('mood').value)
+  };
+  const res = await fetch('/energy', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  document.getElementById('recordResult').textContent = JSON.stringify(data);
+};
+
+document.getElementById('loadProjects').onclick = async () => {
+  const res = await fetch('/projects');
+  const data = await res.json();
+  document.getElementById('projects').textContent = JSON.stringify(data, null, 2);
+};
+
+document.getElementById('loadEnergy').onclick = async () => {
+  const res = await fetch('/energy');
+  const data = await res.json();
+  document.getElementById('energyData').textContent = JSON.stringify(data, null, 2);
+};
+</script>
+</body>
+</html>
+"""
+
+
+@router.get("/", response_class=HTMLResponse)
+def index():
+    """Return the basic web interface."""
+    return HTMLResponse(content=INDEX_HTML)


### PR DESCRIPTION
## Summary
- provide `/parse-projects` API to trigger parsing of the vault
- serve a simple HTML interface at `/`
- document the new API and interface in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68865cae473c8332b57fc137f8ca88ff