### PR TITLE
Add logging to parse_projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Parse the projects and start the API:
 python parse_projects.py
 uvicorn main:app --reload
 ```
+The script writes detailed logs to `parse_projects.log` in the project root.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects and record energy.


### PR DESCRIPTION
## Summary
- write detailed logs to `parse_projects.log`
- note log file in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866a18c974833291066569a200200a