### PR TITLE
Fix import lint warnings

### DIFF
--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -1,59 +1,78 @@
+"""Unit tests for the project parsing utilities."""
+
+from __future__ import annotations
+
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
 
-import sys
-from pathlib import Path as _Path
-
-ROOT = _Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 import parse_projects
-from parse_projects import extract_frontmatter, extract_tasks, summarize_body, parse_markdown_file
+from parse_projects import (
+    extract_frontmatter,
+    extract_tasks,
+    summarize_body,
+    parse_markdown_file,
+)
 
 
 def test_extract_frontmatter():
-    md = textwrap.dedent("""---
+    """Ensure YAML frontmatter is parsed correctly."""
+    md = textwrap.dedent(
+        """---
 status: active
 area: work
 effort: high
 ---
 Body text
-""")
+"""
+    )
     frontmatter, body = extract_frontmatter(md)
     assert frontmatter == {"status": "active", "area": "work", "effort": "high"}
     assert body == "Body text"
 
 
 def test_extract_tasks():
-    body = textwrap.dedent("""- [ ] Task one
+    """Extract markdown tasks from the body."""
+    body = textwrap.dedent(
+        """- [ ] Task one
 - [x] Task two
 Other line
-""")
+"""
+    )
     tasks = extract_tasks(body)
     assert tasks == ["- [ ] Task one", "- [x] Task two"]
 
 
 def test_summarize_body():
-    text = textwrap.dedent("""# Heading
+    """Summarize the body by returning the first paragraph."""
+    text = textwrap.dedent(
+        """# Heading
 Paragraph one.
 
 > quoted text
 
 Paragraph two.
-""")
+"""
+    )
     assert summarize_body(text) == "Paragraph one."
 
 
 def test_parse_markdown_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    md_content = textwrap.dedent("""---
+    """Parse a markdown file and return expected metadata."""
+    md_content = textwrap.dedent(
+        """---
 status: active
 ---
 Some body
 - [ ] Task
-""")
+"""
+    )
     md_file = tmp_path / "example.md"
     md_file.write_text(md_content, encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- clean up test imports and add docstrings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866b2e930883329b770dec81ca3d50