### PR TITLE
Fix imports for tests

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -3,3 +3,4 @@
 1. **Pydantic compatibility** - Updated `config.py` to use `BaseSettings` from `pydantic-settings` so the project works with Pydantic v2.
 2. **Missing packages** - Added `fastapi` and `uvicorn` to `requirements.txt` so the API runs without extra installs.
 3. **Import errors** - All dependencies are now version pinned in `requirements.txt` and the README instructs running `pip install -r requirements.txt` to resolve `E0401` errors.
+4. **Test imports** - Added `pytest` to `requirements.txt` and reorganized `tests/test_parse_projects.py` so linting no longer reports import errors.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
    ```bash
    pip install -r requirements.txt
    ```
-   All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, and `uvicorn` are now version pinned. If you see import errors like `E0401`, make sure these packages are installed by running the above command.
+   All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
 3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `vault/Projects`.
 4. Ensure the vault directory exists and contains markdown project files.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydantic-settings>=2,<3
 pyyaml==6.0.2
 fastapi==0.116.1
 uvicorn==0.35.0
+pytest==8.4.1

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 import sys
-import textwrap
 from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import textwrap
 import pytest
-
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
 import parse_projects
 from parse_projects import (


### PR DESCRIPTION
## Summary
- pin pytest for running tests
- clarify pytest in README setup instructions
- tidy imports in tests
- document fix

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68866c6528808332bd893a2b7cbefa4e