### PR TITLE
Fix test imports

### DIFF
--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+# pylint: disable=wrong-import-position
+
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 import textwrap
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import parse_projects
 from parse_projects import (


### PR DESCRIPTION
## Summary
- adjust test imports to silence linter warnings
- install requirements to resolve missing modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866da2560483329809807250d44ae6