### PR TITLE
Add Black workflow

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,27 @@
+name: Black
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Black
+      run: |
+        python -m pip install --upgrade pip
+        pip install black==25.1.0
+    - name: Check code formatting
+      run: |
+        black --check $(git ls-files '*.py')

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Record today's energy and mood from the command line:
 python record_energy.py 7 8
 ```
 
+## Development
+Pushes and pull requests run automated checks on GitHub Actions. Formatting is
+verified with **Black**, linting with Pylint and Flake8, and tests are executed
+with Pytest. To avoid CI failures, format your code locally before committing:
+```bash
+black .
+```
+
 ## Roadmap
 See [Mindloom Roadmap.md](Mindloom%20Roadmap.md) for planned phases and upcoming features.
 

--- a/config.py
+++ b/config.py
@@ -13,8 +13,10 @@ if Path(".env.local").exists():
 # === Dynamically detect project root ===
 PROJECT_ROOT = Path(__file__).resolve().parent
 
+
 class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     """Centralized application settings."""
+
     # === General ===
     ENVIRONMENT: str = Field("development", env="ENVIRONMENT")
     DEBUG: bool = Field(True, env="DEBUG")
@@ -23,7 +25,9 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     # === Paths ===
     VAULT_PATH: Path = Field(PROJECT_ROOT / "vault/Projects", env="VAULT_PATH")
     OUTPUT_PATH: Path = Field(PROJECT_ROOT / "projects.yaml", env="OUTPUT_PATH")
-    ENERGY_LOG_PATH: Path = Field(PROJECT_ROOT / "energy_log.yaml", env="ENERGY_LOG_PATH")
+    ENERGY_LOG_PATH: Path = Field(
+        PROJECT_ROOT / "energy_log.yaml", env="ENERGY_LOG_PATH"
+    )
 
     # === Optional tokens ===
     OPENAI_API_KEY: str = Field(default="", env="OPENAI_API_KEY")
@@ -33,5 +37,6 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
         env_file=".env",
         env_file_encoding="utf-8",
     )
+
 
 config = Config()

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -20,6 +20,7 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 VALID_KEYS = {"status", "area", "effort", "due"}
 
+
 def extract_frontmatter(text):
     """Return frontmatter dict and remaining body from a markdown string."""
     if text.startswith("---"):
@@ -29,14 +30,16 @@ def extract_frontmatter(text):
                 front = yaml.safe_load(text[3:end])
                 data = {k: front.get(k) for k in VALID_KEYS if k in front}
                 logger.debug("Parsed frontmatter: %s", data)
-                return data, text[end+3:].strip()
+                return data, text[end + 3 :].strip()
             except yaml.YAMLError as exc:
                 logger.warning("Failed to parse frontmatter: %s", exc)
     return {}, text
 
+
 def extract_tasks(text):
     """Extract markdown task list items."""
     return re.findall(r"- \[[ xX]\] .+", text)
+
 
 def summarize_body(text, max_chars=300):
     """Return the first paragraph without headings or block quotes."""
@@ -44,6 +47,7 @@ def summarize_body(text, max_chars=300):
     body = re.sub(r"> .*", "", body)
     paras = [p.strip() for p in body.split("\n\n") if p.strip()]
     return paras[0][:max_chars] if paras else ""
+
 
 def parse_markdown_file(filepath):
     """Parse a single markdown project file."""
@@ -63,6 +67,7 @@ def parse_markdown_file(filepath):
     logger.debug("Parsed data for %s: %s", filepath, data)
     return data
 
+
 def parse_all_projects(root=PROJECTS_DIR):
     """Return a list of parsed projects from the given directory."""
     logger.info("Scanning %s for markdown files", root)
@@ -71,6 +76,7 @@ def parse_all_projects(root=PROJECTS_DIR):
     projects = [parse_markdown_file(md) for md in md_files]
     logger.info("Parsed %d projects", len(projects))
     return projects
+
 
 if __name__ == "__main__":
     logger.info("Starting project parsing")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml==6.0.2
 fastapi==0.116.1
 uvicorn==0.35.0
 pytest==8.4.1
+black==25.1.0

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -12,6 +12,7 @@ from config import config
 router = APIRouter()
 PROJECTS_FILE = config.OUTPUT_PATH
 
+
 @router.get("/projects")
 def get_projects(
     status: Optional[str] = Query(None),

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import textwrap


### PR DESCRIPTION
## Summary
- enforce Black formatting in CI
- document automated formatting in README
- add Black to requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `black --check $(git ls-files '*.py')` (after running black)

------
https://chatgpt.com/codex/tasks/task_e_68866eaa4e1083329e33ae69516030d5