### PR TITLE
Fix Pylint errors

### DIFF
--- a/energy.py
+++ b/energy.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, cast
 import yaml
 
 from config import config
 
-ENERGY_LOG_PATH = config.ENERGY_LOG_PATH
+ENERGY_LOG_PATH: Path = cast(Path, config.ENERGY_LOG_PATH)
 ENERGY_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -3,13 +3,14 @@
 import re
 import logging
 from pathlib import Path
+from typing import cast
 import yaml
 
 from config import config
 
-PROJECTS_DIR = config.VAULT_PATH
-OUTPUT_FILE = config.OUTPUT_PATH
-LOG_FILE = config.LOG_DIR / "parse_projects.log"
+PROJECTS_DIR: Path = cast(Path, config.VAULT_PATH)
+OUTPUT_FILE: Path = cast(Path, config.OUTPUT_PATH)
+LOG_FILE: Path = cast(Path, config.LOG_DIR) / "parse_projects.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 logger = logging.getLogger(__name__)

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -1,6 +1,7 @@
 """API routes for project information."""
 
-from typing import Optional
+from typing import Optional, cast
+from pathlib import Path
 
 import yaml
 from fastapi import APIRouter, Query
@@ -10,7 +11,7 @@ from parse_projects import parse_all_projects
 from config import config
 
 router = APIRouter()
-PROJECTS_FILE = config.OUTPUT_PATH
+PROJECTS_FILE: Path = cast(Path, config.OUTPUT_PATH)
 
 
 @router.get("/projects")


### PR DESCRIPTION
## Summary
- cast pydantic settings as `Path` objects in modules using them
- fix unused import warning

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886730d1df48332b99562e8ee98ae51