### PR TITLE
Resolve Pylint path errors

### DIFF
--- a/energy.py
+++ b/energy.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
-from typing import List, Dict, cast
+from typing import List, Dict
 import yaml
 
 from config import config
 
-ENERGY_LOG_PATH: Path = cast(Path, config.ENERGY_LOG_PATH)
+ENERGY_LOG_PATH = Path(config.ENERGY_LOG_PATH)
 ENERGY_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
 

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -3,14 +3,13 @@
 import re
 import logging
 from pathlib import Path
-from typing import cast
 import yaml
 
 from config import config
 
-PROJECTS_DIR: Path = cast(Path, config.VAULT_PATH)
-OUTPUT_FILE: Path = cast(Path, config.OUTPUT_PATH)
-LOG_FILE: Path = cast(Path, config.LOG_DIR) / "parse_projects.log"
+PROJECTS_DIR = Path(config.VAULT_PATH)
+OUTPUT_FILE = Path(config.OUTPUT_PATH)
+LOG_FILE = Path(config.LOG_DIR) / "parse_projects.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 logger = logging.getLogger(__name__)

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -1,6 +1,6 @@
 """API routes for project information."""
 
-from typing import Optional, cast
+from typing import Optional
 from pathlib import Path
 
 import yaml
@@ -11,7 +11,7 @@ from parse_projects import parse_all_projects
 from config import config
 
 router = APIRouter()
-PROJECTS_FILE: Path = cast(Path, config.OUTPUT_PATH)
+PROJECTS_FILE = Path(config.OUTPUT_PATH)
 
 
 @router.get("/projects")


### PR DESCRIPTION
## Summary
- instantiate paths using `Path()` instead of casting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68867561a1fc83329c282df848f7b79f