### PR TITLE
Add logging across modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ python parse_projects.py
 uvicorn main:app --reload
 ```
 The script writes detailed logs to `data/parse_projects.log`.
+Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects and record energy.

--- a/energy.py
+++ b/energy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import date
 from pathlib import Path
 from typing import List, Dict
+import logging
 import yaml
 
 from config import config
@@ -12,21 +13,37 @@ from config import config
 ENERGY_LOG_PATH = Path(config.ENERGY_LOG_PATH)
 ENERGY_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
+LOG_FILE = Path(config.LOG_DIR) / "energy.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
 
 def read_entries(path: Path = ENERGY_LOG_PATH) -> List[Dict]:
     """Return all energy entries from the log file."""
+    logger.info("Reading energy log from %s", path)
     if not path.exists():
+        logger.info("%s does not exist", path)
         return []
     with open(path, "r", encoding="utf-8") as handle:
         data = yaml.safe_load(handle) or []
+    logger.debug("Loaded %d entries", len(data))
     return data
 
 
 def record_entry(energy: int, mood: int, path: Path = ENERGY_LOG_PATH) -> Dict:
     """Append a new energy/mood entry and return it."""
+    logger.info("Recording energy=%s mood=%s", energy, mood)
     entry = {"date": date.today().isoformat(), "energy": energy, "mood": mood}
     entries = read_entries(path)
     entries.append(entry)
     with open(path, "w", encoding="utf-8") as handle:
         yaml.dump(entries, handle, allow_unicode=True, sort_keys=False)
+    logger.info("Wrote %d entries to %s", len(entries), path)
     return entry

--- a/main.py
+++ b/main.py
@@ -1,9 +1,26 @@
 """FastAPI application entrypoint."""
 
 from fastapi import FastAPI
-from routes import projects, energy, web
+import logging
+from pathlib import Path
 
+from routes import projects, energy, web
+from config import config
+
+LOG_FILE = Path(config.LOG_DIR) / "server.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+logger.info("Initializing FastAPI app")
 app = FastAPI()
 app.include_router(projects.router)
 app.include_router(energy.router)
 app.include_router(web.router)
+logger.info("Routers registered")

--- a/record_energy.py
+++ b/record_energy.py
@@ -1,7 +1,22 @@
 """CLI script to record daily energy and mood."""
 
 import argparse
+import logging
+from pathlib import Path
+
 from energy import record_entry
+from config import config
+
+LOG_FILE = Path(config.LOG_DIR) / "energy.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 
 parser = argparse.ArgumentParser(description="Record today's energy and mood")
 parser.add_argument("energy", type=int, help="Energy level 1-10")
@@ -9,5 +24,7 @@ parser.add_argument("mood", type=int, help="Mood level 1-10")
 
 args = parser.parse_args()
 
+logger.info("CLI invoked with energy=%s mood=%s", args.energy, args.mood)
 entry = record_entry(args.energy, args.mood)
+logger.info("Recorded entry: %s", entry)
 print(f"Recorded: {entry}")

--- a/routes/energy.py
+++ b/routes/energy.py
@@ -1,11 +1,25 @@
 """API routes for recording daily energy and mood."""
 
 from fastapi import APIRouter
+import logging
+from pathlib import Path
 from pydantic import BaseModel
 
 from energy import read_entries, record_entry
+from config import config
 
 router = APIRouter()
+
+LOG_FILE = Path(config.LOG_DIR) / "energy_api.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 
 
 class EnergyInput(BaseModel):  # pylint: disable=too-few-public-methods
@@ -18,10 +32,16 @@ class EnergyInput(BaseModel):  # pylint: disable=too-few-public-methods
 @router.post("/energy")
 def add_energy(data: EnergyInput):
     """Record today's energy and mood."""
-    return record_entry(data.energy, data.mood)
+    logger.info("POST /energy energy=%s mood=%s", data.energy, data.mood)
+    entry = record_entry(data.energy, data.mood)
+    logger.info("Recorded entry: %s", entry)
+    return entry
 
 
 @router.get("/energy")
 def get_energy():
     """Return all recorded energy entries."""
-    return read_entries()
+    logger.info("GET /energy")
+    entries = read_entries()
+    logger.info("Returning %d entries", len(entries))
+    return entries

--- a/routes/web.py
+++ b/routes/web.py
@@ -2,8 +2,23 @@
 
 from fastapi import APIRouter
 from fastapi.responses import HTMLResponse
+import logging
+from pathlib import Path
+
+from config import config
 
 router = APIRouter()
+
+LOG_FILE = Path(config.LOG_DIR) / "web.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
 
 INDEX_HTML = """
 <!DOCTYPE html>
@@ -70,4 +85,5 @@ document.getElementById('loadEnergy').onclick = async () => {
 @router.get("/", response_class=HTMLResponse)
 def index():
     """Return the basic web interface."""
+    logger.info("GET /")
     return HTMLResponse(content=INDEX_HTML)


### PR DESCRIPTION
## Summary
- add per-module loggers for server, energy, web, and project APIs
- log CLI usage when recording energy
- log API endpoint calls and operations
- note logging directories in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886765203d483328054f9be3a5debdf