### PR TITLE
Handle vault path expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
    pip install -r requirements.txt
    ```
    All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
-3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `vault/Projects`.
+3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `vault/Projects`. Paths containing `~` are expanded to your home directory.
 4. Ensure the vault directory exists and contains markdown project files.
 5. Create a `data` directory to persist logs:
    ```bash

--- a/config.py
+++ b/config.py
@@ -40,5 +40,12 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
         env_file_encoding="utf-8",
     )
 
+    def model_post_init(self, __context):  # type: ignore[override]
+        """Expand user home in any path settings."""
+        self.VAULT_PATH = self.VAULT_PATH.expanduser()
+        self.OUTPUT_PATH = self.OUTPUT_PATH.expanduser()
+        self.LOG_DIR = self.LOG_DIR.expanduser()
+        self.ENERGY_LOG_PATH = self.ENERGY_LOG_PATH.expanduser()
+
 
 config = Config()

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -71,7 +71,10 @@ def parse_markdown_file(filepath):
 
 def parse_all_projects(root=PROJECTS_DIR):
     """Return a list of parsed projects from the given directory."""
+    root = Path(root).expanduser()
     logger.info("Scanning %s for markdown files", root)
+    if not root.is_dir():
+        raise FileNotFoundError(f"{root} does not exist")
     md_files = list(root.rglob("*.md"))
     logger.info("Found %d markdown files", len(md_files))
     projects = [parse_markdown_file(md) for md in md_files]

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -82,3 +82,28 @@ Some body
     assert result["title"] == "example"
     assert result["status"] == "active"
     assert result["tasks"] == ["- [ ] Task"]
+
+
+def test_parse_all_projects_expands_tilde(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """parse_all_projects should expand '~' in the vault path."""
+    home = tmp_path / "home"
+    vault = home / "vault" / "Projects"
+    vault.mkdir(parents=True)
+    md_file = vault / "note.md"
+    md_file.write_text("Body", encoding="utf-8")
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("VAULT_PATH", "~/vault/Projects")
+
+    import importlib
+    import config as cfg
+
+    importlib.reload(cfg)
+    import parse_projects as pp
+
+    importlib.reload(pp)
+
+    projects = pp.parse_all_projects()
+    assert projects[0]["title"] == "note"


### PR DESCRIPTION
## Summary
- expand user directories in `Config`
- ensure `parse_all_projects` validates the path and expands `~`
- clarify README about tilde expansion in `VAULT_PATH`
- test path expansion in `parse_all_projects`

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886796bffe88332a9ce4ca6f8f49b95