### PR TITLE
Fix default vault path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
    pip install -r requirements.txt
    ```
    All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
-3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `vault/Projects`. Paths containing `~` are expanded to your home directory.
+3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `/vault/Projects` when that folder exists, otherwise `vault/Projects` relative to the project root. Paths containing `~` are expanded to your home directory.
 4. Ensure the vault directory exists and contains markdown project files.
 5. Create a `data` directory to persist logs:
    ```bash

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 """Application configuration handled via environment variables."""
 
 from pathlib import Path
+from typing import ClassVar
 from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -23,7 +24,12 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     PORT: int = Field(8000, env="PORT")
 
     # === Paths ===
-    VAULT_PATH: Path = Field(PROJECT_ROOT / "vault/Projects", env="VAULT_PATH")
+    DEFAULT_VAULT: ClassVar[Path] = (
+        Path("/vault/Projects")
+        if Path("/vault/Projects").exists()
+        else PROJECT_ROOT / "vault/Projects"
+    )
+    VAULT_PATH: Path = Field(DEFAULT_VAULT, env="VAULT_PATH")
     OUTPUT_PATH: Path = Field(PROJECT_ROOT / "projects.yaml", env="OUTPUT_PATH")
 
     LOG_DIR: Path = Field(PROJECT_ROOT / "data", env="LOG_DIR")


### PR DESCRIPTION
## Summary
- detect `/vault/Projects` and use it as the default vault path
- document the new default path in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867b379b408332ac8545fdba6e7fad