### PR TITLE
Add tasks export

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 ## Features
 - Parse markdown project files from a configured vault directory.
 - Store project metadata and summaries in `projects.yaml`.
+- Convert parsed projects into task entries saved in `tasks.yml`.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
+- Save tasks via the `/save-tasks` API endpoint or the web interface.
 - Containerized setup using Docker and docker-compose.
 
 ## Setup

--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     )
     VAULT_PATH: Path = Field(DEFAULT_VAULT, env="VAULT_PATH")
     OUTPUT_PATH: Path = Field(PROJECT_ROOT / "projects.yaml", env="OUTPUT_PATH")
+    TASKS_PATH: Path = Field(PROJECT_ROOT / "tasks.yml", env="TASKS_PATH")
 
     LOG_DIR: Path = Field(PROJECT_ROOT / "data", env="LOG_DIR")
     ENERGY_LOG_PATH: Path = Field(
@@ -52,6 +53,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
         """Expand user home in any path settings."""
         self.VAULT_PATH = self.VAULT_PATH.expanduser()
         self.OUTPUT_PATH = self.OUTPUT_PATH.expanduser()
+        self.TASKS_PATH = self.TASKS_PATH.expanduser()
         self.LOG_DIR = self.LOG_DIR.expanduser()
         self.ENERGY_LOG_PATH = self.ENERGY_LOG_PATH.expanduser()
 

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -9,12 +9,13 @@ from typing import Optional
 import yaml
 from fastapi import APIRouter, Query
 
-from parse_projects import parse_all_projects
+from parse_projects import parse_all_projects, save_tasks_yaml
 
 from config import config
 
 router = APIRouter()
 PROJECTS_FILE = Path(config.OUTPUT_PATH)
+TASKS_FILE = Path(config.TASKS_PATH)
 
 LOG_FILE = Path(config.LOG_DIR) / "projects.log"
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -68,3 +69,13 @@ def parse_projects_endpoint():
         yaml.dump(projects, f, sort_keys=False, allow_unicode=True)
     logger.info("Parsed %d projects", len(projects))
     return {"count": len(projects)}
+
+
+@router.post("/save-tasks")
+def save_tasks_endpoint():
+    """Parse projects and write tasks.yml."""
+    logger.info("POST /save-tasks")
+    projects = parse_all_projects()
+    tasks = save_tasks_yaml(projects, TASKS_FILE)
+    logger.info("Saved %d tasks", len(tasks))
+    return {"count": len(tasks)}

--- a/routes/web.py
+++ b/routes/web.py
@@ -33,7 +33,9 @@ INDEX_HTML = """
   <h1>Mindloom Interface</h1>
   <h2>Parse Projects</h2>
   <button id=\"parseBtn\">Parse</button>
+  <button id=\"tasksBtn\">Save Tasks</button>
   <pre id=\"parseResult\"></pre>
+  <pre id=\"tasksResult\"></pre>
   <h2>Record Energy</h2>
   <input type=\"number\" id=\"energy\" placeholder=\"Energy 1-10\">
   <input type=\"number\" id=\"mood\" placeholder=\"Mood 1-10\">
@@ -51,6 +53,13 @@ parseBtn.onclick = async () => {
   const res = await fetch('/parse-projects', {method: 'POST'});
   const data = await res.json();
   document.getElementById('parseResult').textContent = JSON.stringify(data);
+};
+
+const tasksBtn = document.getElementById('tasksBtn');
+tasksBtn.onclick = async () => {
+  const res = await fetch('/save-tasks', {method: 'POST'});
+  const data = await res.json();
+  document.getElementById('tasksResult').textContent = JSON.stringify(data);
 };
 
 const recordBtn = document.getElementById('recordBtn');

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 import textwrap
+import yaml
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -107,3 +108,26 @@ def test_parse_all_projects_expands_tilde(
 
     projects = pp.parse_all_projects()
     assert projects[0]["title"] == "note"
+
+
+def test_save_tasks_yaml(tmp_path: Path):
+    """save_tasks_yaml should write tasks in the expected format."""
+    projects = [
+        {
+            "title": "demo",
+            "path": "demo.md",
+            "area": "work",
+            "effort": "medium",
+            "status": "active",
+        }
+    ]
+    tasks_file = tmp_path / "tasks.yml"
+    from parse_projects import save_tasks_yaml
+
+    tasks = save_tasks_yaml(projects, tasks_file)
+    with open(tasks_file, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+
+    assert tasks == data
+    assert data[0]["title"] == "demo"
+    assert data[0]["type"] == "project"


### PR DESCRIPTION
## Summary
- configure TASKS_PATH in `config`
- save tasks YAML via `projects_to_tasks` and `save_tasks_yaml`
- expose `/save-tasks` API endpoint
- add a Save Tasks button to the web UI
- document new endpoint and feature
- test task saving

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886825fb108833295914ccec0a1b5d1