### PR TITLE
Update tasks path to data folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 ## Features
 - Parse markdown project files from a configured vault directory.
 - Store project metadata and summaries in `projects.yaml`.
-- Convert parsed projects into task entries saved in `tasks.yml`.
+- Convert parsed projects into task entries saved in `data/tasks.yml`.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.

--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     )
     VAULT_PATH: Path = Field(DEFAULT_VAULT, env="VAULT_PATH")
     OUTPUT_PATH: Path = Field(PROJECT_ROOT / "projects.yaml", env="OUTPUT_PATH")
-    TASKS_PATH: Path = Field(PROJECT_ROOT / "tasks.yml", env="TASKS_PATH")
+    TASKS_PATH: Path = Field(PROJECT_ROOT / "data/tasks.yml", env="TASKS_PATH")
 
     LOG_DIR: Path = Field(PROJECT_ROOT / "data", env="LOG_DIR")
     ENERGY_LOG_PATH: Path = Field(

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -73,7 +73,7 @@ def parse_projects_endpoint():
 
 @router.post("/save-tasks")
 def save_tasks_endpoint():
-    """Parse projects and write tasks.yml."""
+    """Parse projects and write data/tasks.yml."""
     logger.info("POST /save-tasks")
     projects = parse_all_projects()
     tasks = save_tasks_yaml(projects, TASKS_FILE)


### PR DESCRIPTION
## Summary
- store tasks.yml in `data`
- document new location in README
- update save-tasks route docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868496c720833281473d330e591220