### PR TITLE
Update mood dropdown with emoji and energy scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Open `http://localhost:8000/` in a browser for a simple web interface to parse p
 
 Record today's energy and mood from the command line:
 ```bash
-python record_energy.py 7 8
+python record_energy.py 3 Upbeat
 ```
+Energy is scored 1-5 and mood accepts one of Focused, Tired, Flat, Anxious or Upbeat.
 Energy entries are stored in `data/energy_log.yaml`.
 
 ## Development

--- a/energy.py
+++ b/energy.py
@@ -39,10 +39,23 @@ def read_entries(path: Path = ENERGY_LOG_PATH) -> List[Dict]:
     return data
 
 
-def record_entry(energy: int, mood: int, path: Path = ENERGY_LOG_PATH) -> Dict:
+MOOD_EMOJIS = {
+    "Focused": "🎯",
+    "Tired": "😴",
+    "Flat": "😐",
+    "Anxious": "😰",
+    "Upbeat": "😃",
+}
+
+
+def record_entry(energy: int, mood: str, path: Path = ENERGY_LOG_PATH) -> Dict:
     """Append a new energy/mood entry and return it."""
     logger.info("Recording energy=%s mood=%s", energy, mood)
-    entry = {"date": date.today().isoformat(), "energy": energy, "mood": mood}
+    entry = {
+        "date": date.today().isoformat(),
+        "energy": energy,
+        "mood": mood,
+    }
     entries = read_entries(path)
     entries.append(entry)
     with open(path, "w", encoding="utf-8") as handle:

--- a/record_energy.py
+++ b/record_energy.py
@@ -21,8 +21,13 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 parser = argparse.ArgumentParser(description="Record today's energy and mood")
-parser.add_argument("energy", type=int, help="Energy level 1-10")
-parser.add_argument("mood", type=int, help="Mood level 1-10")
+parser.add_argument("energy", type=int, choices=range(1, 6), help="Energy level 1-5")
+parser.add_argument(
+    "mood",
+    type=str,
+    choices=["Focused", "Tired", "Flat", "Anxious", "Upbeat"],
+    help="Mood",
+)
 
 args = parser.parse_args()
 

--- a/routes/energy.py
+++ b/routes/energy.py
@@ -29,7 +29,7 @@ class EnergyInput(BaseModel):  # pylint: disable=too-few-public-methods
     """Input model for energy submissions."""
 
     energy: int
-    mood: int
+    mood: str
 
 
 @router.post("/energy")

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,8 +20,20 @@
     <section class="space-y-2">
       <h2 class="text-xl font-semibold">Record Energy</h2>
       <div class="flex gap-2">
-        <input type="number" id="energy" placeholder="Energy 1-10" class="border p-1 flex-1">
-        <input type="number" id="mood" placeholder="Mood 1-10" class="border p-1 flex-1">
+        <select id="energy" class="border p-1 flex-1">
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+        </select>
+        <select id="mood" class="border p-1 flex-1">
+          <option value="Focused">🎯 Focused</option>
+          <option value="Tired">😴 Tired</option>
+          <option value="Flat">😐 Flat</option>
+          <option value="Anxious">😰 Anxious</option>
+          <option value="Upbeat">😃 Upbeat</option>
+        </select>
         <button id="recordBtn" class="px-3 py-1 bg-blue-500 text-white rounded">Record</button>
       </div>
       <pre id="recordResult" class="bg-gray-100 p-2 rounded"></pre>
@@ -56,7 +68,7 @@ const recordBtn = document.getElementById('recordBtn');
 recordBtn.onclick = async () => {
   const payload = {
     energy: parseInt(document.getElementById('energy').value),
-    mood: parseInt(document.getElementById('mood').value)
+    mood: document.getElementById('mood').value
   };
   const res = await fetch('/energy', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- add mood emojis and store mood as text
- switch energy level to 1-5
- use dropdowns on the web interface for energy and mood
- support new arguments in `record_energy.py`
- document new CLI usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68868e4ee0608332bd9408aa21d6392b