### PR TITLE
Include last reviewed date in project tasks

### DIFF
--- a/parse_projects.py
+++ b/parse_projects.py
@@ -23,7 +23,7 @@ if not logger.handlers:
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
-VALID_KEYS = {"status", "area", "effort", "due"}
+VALID_KEYS = {"status", "area", "effort", "due", "last_reviewed"}
 
 
 def extract_frontmatter(text):
@@ -101,8 +101,7 @@ def projects_to_tasks(projects):
             "energy_cost": mapping.get(proj.get("effort", "low"), 1),
             "status": proj.get("status", "active"),
         }
-        if proj.get("last_reviewed"):
-            task["last_reviewed"] = proj["last_reviewed"]
+        task["last_reviewed"] = proj.get("last_reviewed")
         tasks.append(task)
     return tasks
 

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -28,12 +28,16 @@ def test_extract_frontmatter():
 status: active
 area: work
 effort: high
+last_reviewed: 2024-01-01
 ---
 Body text
 """
     )
     frontmatter, body = extract_frontmatter(md)
-    assert frontmatter == {"status": "active", "area": "work", "effort": "high"}
+    assert frontmatter["status"] == "active"
+    assert frontmatter["area"] == "work"
+    assert frontmatter["effort"] == "high"
+    assert str(frontmatter["last_reviewed"]) == "2024-01-01"
     assert body == "Body text"
 
 
@@ -68,6 +72,7 @@ def test_parse_markdown_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     md_content = textwrap.dedent(
         """---
 status: active
+last_reviewed: 2024-02-02
 ---
 Some body
 - [ ] Task
@@ -82,6 +87,7 @@ Some body
 
     assert result["title"] == "example"
     assert result["status"] == "active"
+    assert str(result["last_reviewed"]) == "2024-02-02"
     assert result["tasks"] == ["- [ ] Task"]
 
 
@@ -131,3 +137,5 @@ def test_save_tasks_yaml(tmp_path: Path):
     assert tasks == data
     assert data[0]["title"] == "demo"
     assert data[0]["type"] == "project"
+    assert "last_reviewed" in data[0]
+    assert data[0]["last_reviewed"] is None


### PR DESCRIPTION
## Summary
- parse `last_reviewed` from project frontmatter
- always include `last_reviewed` field when converting projects to tasks
- test handling of `last_reviewed` dates

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688696302c0c8332a6022ab8ab4ea9fd