### PR TITLE
Add Jinja2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
    ```bash
    pip install -r requirements.txt
    ```
-   All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
+   All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, `jinja2`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
 3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `/vault/Projects` when that folder exists, otherwise `vault/Projects` relative to the project root. Paths containing `~` are expanded to your home directory.
 4. Ensure the vault directory exists and contains markdown project files.
 5. Create a `data` directory to persist logs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pydantic-settings>=2,<3
 pyyaml==6.0.2
 fastapi==0.116.1
 uvicorn==0.35.0
+jinja2==3.1.6
 pytest==8.4.1
 black==25.1.0


### PR DESCRIPTION
## Summary
- add Jinja2 to requirements
- document Jinja2 in install instructions

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869bc10fb883328821026a9807ff08