### PR TITLE
Add prompt rendering dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
+- Render prompt templates via the `/render-prompt` API or the web interface.
 - Containerized setup using Docker and docker-compose.
 
 ## Setup
@@ -43,7 +44,7 @@ The script writes detailed logs to `data/parse_projects.log`.
 Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
-Open `http://localhost:8000/` in a browser for a simple web interface to parse projects and record energy.
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy and render prompt templates.
 
 Record today's energy and mood from the command line:
 ```bash

--- a/prompt_renderer.py
+++ b/prompt_renderer.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from jinja2 import Template
+
+
+def render_prompt(template_path: str, variables: dict) -> str:
+    """Return a rendered prompt given a template path and variables."""
+    template_text = Path(template_path).read_text()
+    template = Template(template_text)
+    return template.render(**variables)

--- a/routes/web.py
+++ b/routes/web.py
@@ -5,11 +5,12 @@
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Body
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from config import config, PROJECT_ROOT
+from prompt_renderer import render_prompt
 
 
 router = APIRouter()
@@ -31,4 +32,22 @@ if not logger.handlers:
 def index(request: Request):
     """Return the basic web interface."""
     logger.info("GET /")
-    return templates.TemplateResponse("index.html", {"request": request})
+    prompts_dir = PROJECT_ROOT / "prompts"
+    prompt_files = [
+        p.relative_to(prompts_dir).as_posix() for p in prompts_dir.rglob("*.txt")
+    ]
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "prompt_files": prompt_files},
+    )
+
+
+@router.post("/render-prompt")
+def render_prompt_endpoint(data: dict = Body(...)):
+    """Render a prompt template with optional variables."""
+    template_name = data.get("template")
+    variables = data.get("variables", {})
+    prompts_dir = PROJECT_ROOT / "prompts"
+    template_path = prompts_dir / template_name
+    result = render_prompt(str(template_path), variables)
+    return {"result": result}

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,6 +47,18 @@
       <pre id="projects" class="bg-gray-100 p-2 rounded"></pre>
       <pre id="energyData" class="bg-gray-100 p-2 rounded"></pre>
     </section>
+    <section class="space-y-2">
+      <h2 class="text-xl font-semibold">Prompts</h2>
+      <div class="flex gap-2">
+        <select id="promptSelect" class="border p-1 flex-1">
+          {% for p in prompt_files %}
+          <option value="{{ p }}">{{ p }}</option>
+          {% endfor %}
+        </select>
+        <button id="renderPrompt" class="px-3 py-1 bg-blue-500 text-white rounded">Render</button>
+      </div>
+      <pre id="promptResult" class="bg-gray-100 p-2 rounded"></pre>
+    </section>
   </div>
 
 <script>
@@ -89,6 +101,18 @@ document.getElementById('loadEnergy').onclick = async () => {
   const res = await fetch('/energy');
   const data = await res.json();
   document.getElementById('energyData').textContent = JSON.stringify(data, null, 2);
+};
+
+document.getElementById('renderPrompt').onclick = async () => {
+  const select = document.getElementById('promptSelect');
+  const payload = { template: select.value, variables: {} };
+  const res = await fetch('/render-prompt', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  document.getElementById('promptResult').textContent = data.result;
 };
 </script>
 </body>


### PR DESCRIPTION
## Summary
- list available prompt templates in dropdown on the index page
- add endpoint and helper to render selected prompt
- update README with usage of `/render-prompt`

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68869ec1db5c833285ba5d7a31d33a61