### PR TITLE
Fix pylint warnings in prompt_renderer

### DIFF
--- a/prompt_renderer.py
+++ b/prompt_renderer.py
@@ -1,9 +1,11 @@
+"""Utility for rendering Jinja templates used in the prompts."""
+
 from pathlib import Path
 from jinja2 import Template
 
 
 def render_prompt(template_path: str, variables: dict) -> str:
     """Return a rendered prompt given a template path and variables."""
-    template_text = Path(template_path).read_text()
+    template_text = Path(template_path).read_text(encoding="utf-8")
     template = Template(template_text)
     return template.render(**variables)


### PR DESCRIPTION
## Summary
- add missing module docstring for `prompt_renderer`
- specify UTF-8 encoding when reading templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869fc2a2ac8332beff9ea4194c83a2