### PR TITLE
Fix prompt variable input

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -4,3 +4,4 @@
 2. **Missing packages** - Added `fastapi` and `uvicorn` to `requirements.txt` so the API runs without extra installs.
 3. **Import errors** - All dependencies are now version pinned in `requirements.txt` and the README instructs running `pip install -r requirements.txt` to resolve `E0401` errors.
 4. **Test imports** - Added `pytest` to `requirements.txt` and reorganized `tests/test_parse_projects.py` so linting no longer reports import errors.
+5. **Prompt variables** - The web interface now includes a JSON textarea so prompts render with provided variables instead of blanks.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy and render prompt templates.
+The prompts section accepts JSON variables. Enter JSON in the textarea next to the dropdown, then click **Render** to see the filled template.
 
 Record today's energy and mood from the command line:
 ```bash

--- a/templates/index.html
+++ b/templates/index.html
@@ -55,6 +55,7 @@
           <option value="{{ p }}">{{ p }}</option>
           {% endfor %}
         </select>
+        <textarea id="promptVars" placeholder="{\"energy\":5}" class="border p-1 flex-1"></textarea>
         <button id="renderPrompt" class="px-3 py-1 bg-blue-500 text-white rounded">Render</button>
       </div>
       <pre id="promptResult" class="bg-gray-100 p-2 rounded"></pre>
@@ -105,7 +106,15 @@ document.getElementById('loadEnergy').onclick = async () => {
 
 document.getElementById('renderPrompt').onclick = async () => {
   const select = document.getElementById('promptSelect');
-  const payload = { template: select.value, variables: {} };
+  const varsText = document.getElementById('promptVars').value || '{}';
+  let variables = {};
+  try {
+    variables = JSON.parse(varsText);
+  } catch {
+    alert('Invalid JSON in variables');
+    return;
+  }
+  const payload = { template: select.value, variables };
   const res = await fetch('/render-prompt', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
## Summary
- allow passing prompt variables via web UI
- document prompt JSON input in README
- log fixed bug

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a4b0d9548332bf9e73af0f69574a