### PR TITLE
Fix render prompt page to load tasks automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
+- Retrieve saved tasks through the `/tasks` API endpoint.
 - Render prompt templates via the `/render-prompt` API or the web interface.
 - Containerized setup using Docker and docker-compose.
 
@@ -45,7 +46,7 @@ Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy and render prompt templates.
-The prompts section accepts JSON variables. Enter JSON in the textarea next to the dropdown, then click **Render** to see the filled template.
+The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yml` when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
 
 Record today's energy and mood from the command line:
 ```bash

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -10,6 +10,7 @@ import yaml
 from fastapi import APIRouter, Query
 
 from parse_projects import parse_all_projects, save_tasks_yaml
+from tasks import read_tasks
 
 from config import config
 
@@ -79,3 +80,12 @@ def save_tasks_endpoint():
     tasks = save_tasks_yaml(projects, TASKS_FILE)
     logger.info("Saved %d tasks", len(tasks))
     return {"count": len(tasks)}
+
+
+@router.get("/tasks")
+def get_tasks():
+    """Return saved tasks from data/tasks.yml."""
+    logger.info("GET /tasks")
+    tasks = read_tasks(TASKS_FILE)
+    logger.info("Returning %d tasks", len(tasks))
+    return tasks

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,36 @@
+"""Utilities for reading saved task entries."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Dict
+import yaml
+
+from config import config
+
+TASKS_FILE = Path(config.TASKS_PATH)
+TASKS_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+LOG_FILE = Path(config.LOG_DIR) / "tasks.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def read_tasks(path: Path = TASKS_FILE) -> List[Dict]:
+    """Return all task entries from the YAML file."""
+    logger.info("Reading tasks from %s", path)
+    if not path.exists():
+        logger.info("%s does not exist", path)
+        return []
+    with open(path, "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or []
+    logger.debug("Loaded %d tasks", len(data))
+    return data

--- a/templates/index.html
+++ b/templates/index.html
@@ -114,6 +114,14 @@ document.getElementById('renderPrompt').onclick = async () => {
     alert('Invalid JSON in variables');
     return;
   }
+  try {
+    const tasksRes = await fetch('/tasks');
+    if (tasksRes.ok) {
+      variables.tasks = await tasksRes.json();
+    }
+  } catch (e) {
+    console.error('Failed to load tasks', e);
+  }
   const payload = { template: select.value, variables };
   const res = await fetch('/render-prompt', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- load saved tasks with new `/tasks` API endpoint
- include tasks when rendering prompt templates in the web UI
- document `/tasks` endpoint and automatic tasks injection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886a884c530833293d5168100a06b15