### PR TITLE
Add free time logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ The service runs on `http://localhost:8000` by default.
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy and render prompt templates.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yml` when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
 
-Record today's energy and mood from the command line:
+Record today's energy, mood and free hours from the command line:
 ```bash
-python record_energy.py 3 Upbeat
+python record_energy.py 3 Upbeat 2
 ```
-Energy is scored 1-5 and mood accepts one of Focused, Tired, Flat, Anxious or Upbeat.
+Energy is scored 1-5, mood accepts one of Focused, Tired, Flat, Anxious or Upbeat,
+and the final argument specifies how many hours of free time you have.
 Energy entries are stored in `data/energy_log.yaml`.
 
 ## Development

--- a/energy.py
+++ b/energy.py
@@ -1,4 +1,4 @@
-"""Utilities for recording daily energy and mood."""
+"""Utilities for recording daily energy, mood and free time."""
 
 # pylint: disable=duplicate-code
 
@@ -48,13 +48,16 @@ MOOD_EMOJIS = {
 }
 
 
-def record_entry(energy: int, mood: str, path: Path = ENERGY_LOG_PATH) -> Dict:
-    """Append a new energy/mood entry and return it."""
-    logger.info("Recording energy=%s mood=%s", energy, mood)
+def record_entry(
+    energy: int, mood: str, hours_free: float, path: Path = ENERGY_LOG_PATH
+) -> Dict:
+    """Append a new energy/mood/free time entry and return it."""
+    logger.info("Recording energy=%s mood=%s hours_free=%s", energy, mood, hours_free)
     entry = {
         "date": date.today().isoformat(),
         "energy": energy,
         "mood": mood,
+        "hours_free": hours_free,
     }
     entries = read_entries(path)
     entries.append(entry)

--- a/record_energy.py
+++ b/record_energy.py
@@ -1,4 +1,4 @@
-"""CLI script to record daily energy and mood."""
+"""CLI script to record daily energy, mood and free time."""
 
 # pylint: disable=duplicate-code
 
@@ -20,7 +20,9 @@ if not logger.handlers:
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
 
-parser = argparse.ArgumentParser(description="Record today's energy and mood")
+parser = argparse.ArgumentParser(
+    description="Record today's energy, mood and free hours"
+)
 parser.add_argument("energy", type=int, choices=range(1, 6), help="Energy level 1-5")
 parser.add_argument(
     "mood",
@@ -28,10 +30,20 @@ parser.add_argument(
     choices=["Focused", "Tired", "Flat", "Anxious", "Upbeat"],
     help="Mood",
 )
+parser.add_argument(
+    "hours_free",
+    type=float,
+    help="Hours of free time available",
+)
 
 args = parser.parse_args()
 
-logger.info("CLI invoked with energy=%s mood=%s", args.energy, args.mood)
-entry = record_entry(args.energy, args.mood)
+logger.info(
+    "CLI invoked with energy=%s mood=%s hours_free=%s",
+    args.energy,
+    args.mood,
+    args.hours_free,
+)
+entry = record_entry(args.energy, args.mood, args.hours_free)
 logger.info("Recorded entry: %s", entry)
 print(f"Recorded: {entry}")

--- a/routes/energy.py
+++ b/routes/energy.py
@@ -1,4 +1,4 @@
-"""API routes for recording daily energy and mood."""
+"""API routes for recording daily energy, mood and free time."""
 
 # pylint: disable=duplicate-code
 
@@ -30,13 +30,19 @@ class EnergyInput(BaseModel):  # pylint: disable=too-few-public-methods
 
     energy: int
     mood: str
+    hours_free: float
 
 
 @router.post("/energy")
 def add_energy(data: EnergyInput):
-    """Record today's energy and mood."""
-    logger.info("POST /energy energy=%s mood=%s", data.energy, data.mood)
-    entry = record_entry(data.energy, data.mood)
+    """Record today's energy, mood and free time."""
+    logger.info(
+        "POST /energy energy=%s mood=%s hours_free=%s",
+        data.energy,
+        data.mood,
+        data.hours_free,
+    )
+    entry = record_entry(data.energy, data.mood, data.hours_free)
     logger.info("Recorded entry: %s", entry)
     return entry
 

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from energy import record_entry, read_entries
+
+
+def test_record_entry_writes_hours_free(tmp_path: Path):
+    path = tmp_path / "energy.yaml"
+    entry = record_entry(3, "Focused", 2.0, path)
+    assert entry["hours_free"] == 2.0
+    entries = read_entries(path)
+    assert entries[-1]["hours_free"] == 2.0


### PR DESCRIPTION
## Summary
- track hours of free time when recording energy
- extend CLI and API to accept hours_free
- document free time logging in README
- test energy logging

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886abd77f1c8332b4f97ed65285b7bd