### PR TITLE
Fix lint errors in tests

### DIFF
--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,5 +1,11 @@
+"""Unit tests for the :mod:`energy` utilities."""
+
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+
+# pylint: disable=wrong-import-position, import-outside-toplevel
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -7,6 +13,7 @@ from energy import record_entry, read_entries
 
 
 def test_record_entry_writes_hours_free(tmp_path: Path):
+    """Record an entry and ensure ``hours_free`` is persisted."""
     path = tmp_path / "energy.yaml"
     entry = record_entry(3, "Focused", 2.0, path)
     assert entry["hours_free"] == 2.0


### PR DESCRIPTION
## Summary
- silence pylint and add missing docs in energy tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b0a919ec8332a8e8015e0481ba5e