### PR TITLE
Enable free hours logging via UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The script writes detailed logs to `data/parse_projects.log`.
 Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
-Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy and render prompt templates.
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free hours) and render prompt templates.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yml` when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
 
 Record today's energy, mood and free hours from the command line:

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,8 @@
           <option value="Anxious">😰 Anxious</option>
           <option value="Upbeat">😃 Upbeat</option>
         </select>
+        <input id="hoursFree" type="number" step="0.25" placeholder="Hours free"
+          class="border p-1 flex-1" />
         <button id="recordBtn" class="px-3 py-1 bg-blue-500 text-white rounded">Record</button>
       </div>
       <pre id="recordResult" class="bg-gray-100 p-2 rounded"></pre>
@@ -81,7 +83,8 @@ const recordBtn = document.getElementById('recordBtn');
 recordBtn.onclick = async () => {
   const payload = {
     energy: parseInt(document.getElementById('energy').value),
-    mood: document.getElementById('mood').value
+    mood: document.getElementById('mood').value,
+    hours_free: parseFloat(document.getElementById('hoursFree').value || '0')
   };
   const res = await fetch('/energy', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- allow recording free hours alongside energy and mood in the web UI
- mention free hours in the README web interface section

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b84054e48332a33736546d012904