### PR TITLE
Enforce single daily energy entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ python record_energy.py 3 Upbeat 2
 Energy is scored 1-5, mood accepts one of Focused, Tired, Flat, Anxious or Upbeat,
 and the final argument specifies how many hours of free time you have.
 Energy entries are stored in `data/energy_log.yaml`.
+Recording again on the same day will update the existing entry instead of adding a new one.
 
 ## Development
 Pushes and pull requests run automated checks on GitHub Actions. Formatting is

--- a/energy.py
+++ b/energy.py
@@ -51,7 +51,11 @@ MOOD_EMOJIS = {
 def record_entry(
     energy: int, mood: str, hours_free: float, path: Path = ENERGY_LOG_PATH
 ) -> Dict:
-    """Append a new energy/mood/free time entry and return it."""
+    """Record today's energy and return the entry.
+
+    Only one entry per day is kept. Repeated calls for the same date will
+    overwrite the previous values.
+    """
     logger.info("Recording energy=%s mood=%s hours_free=%s", energy, mood, hours_free)
     entry = {
         "date": date.today().isoformat(),
@@ -60,7 +64,12 @@ def record_entry(
         "hours_free": hours_free,
     }
     entries = read_entries(path)
-    entries.append(entry)
+    for idx, existing in enumerate(entries):
+        if existing.get("date") == entry["date"]:
+            entries[idx] = entry
+            break
+    else:
+        entries.append(entry)
     with open(path, "w", encoding="utf-8") as handle:
         yaml.dump(entries, handle, allow_unicode=True, sort_keys=False)
     logger.info("Wrote %d entries to %s", len(entries), path)

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -19,3 +19,15 @@ def test_record_entry_writes_hours_free(tmp_path: Path):
     assert entry["hours_free"] == 2.0
     entries = read_entries(path)
     assert entries[-1]["hours_free"] == 2.0
+
+
+def test_record_entry_overwrites_same_day(tmp_path: Path):
+    """Saving multiple times in a day replaces the previous entry."""
+    path = tmp_path / "energy.yaml"
+    record_entry(3, "Focused", 2.0, path)
+    record_entry(4, "Tired", 1.0, path)
+    entries = read_entries(path)
+    assert len(entries) == 1
+    assert entries[0]["energy"] == 4
+    assert entries[0]["mood"] == "Tired"
+    assert entries[0]["hours_free"] == 1.0


### PR DESCRIPTION
## Summary
- prevent duplicate daily entries in energy log
- document overwrite behaviour in README
- test overwriting of same-day entry

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886baa075b88332aac394df9e7656c8