### PR TITLE
Refactor free time to time blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ The script writes detailed logs to `data/parse_projects.log`.
 Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
-Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free hours) and render prompt templates.
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yml` when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
 
-Record today's energy, mood and free hours from the command line:
+Record today's energy, mood and free time blocks from the command line:
 ```bash
-python record_energy.py 3 Upbeat 2
+python record_energy.py 3 Upbeat 8
 ```
 Energy is scored 1-5, mood accepts one of Focused, Tired, Flat, Anxious or Upbeat,
-and the final argument specifies how many hours of free time you have.
+and the final argument specifies how many 15-minute blocks of free time you have.
 Energy entries are stored in `data/energy_log.yaml`.
 Recording again on the same day will update the existing entry instead of adding a new one.
 

--- a/energy.py
+++ b/energy.py
@@ -1,4 +1,4 @@
-"""Utilities for recording daily energy, mood and free time."""
+"""Utilities for recording daily energy, mood and free time blocks."""
 
 # pylint: disable=duplicate-code
 
@@ -49,19 +49,19 @@ MOOD_EMOJIS = {
 
 
 def record_entry(
-    energy: int, mood: str, hours_free: float, path: Path = ENERGY_LOG_PATH
+    energy: int, mood: str, time_blocks: int, path: Path = ENERGY_LOG_PATH
 ) -> Dict:
-    """Record today's energy and return the entry.
+    """Record today's energy and free time blocks, then return the entry.
 
     Only one entry per day is kept. Repeated calls for the same date will
     overwrite the previous values.
     """
-    logger.info("Recording energy=%s mood=%s hours_free=%s", energy, mood, hours_free)
+    logger.info("Recording energy=%s mood=%s time_blocks=%s", energy, mood, time_blocks)
     entry = {
         "date": date.today().isoformat(),
         "energy": energy,
         "mood": mood,
-        "hours_free": hours_free,
+        "time_blocks": time_blocks,
     }
     entries = read_entries(path)
     for idx, existing in enumerate(entries):

--- a/prompts/morning_planner.txt
+++ b/prompts/morning_planner.txt
@@ -2,7 +2,7 @@ You are a helpful assistant that creates a personalized daily plan.
 
 The user has the following:
 - Energy level: {{energy}} / 5
-- Free time blocks today: {{time_blocks}} minutes total
+- Free time blocks today: {{time_blocks}} blocks (15 min each)
 - Available projects (tasks):
 
 {% for task in tasks %}

--- a/record_energy.py
+++ b/record_energy.py
@@ -1,4 +1,4 @@
-"""CLI script to record daily energy, mood and free time."""
+"""CLI script to record daily energy, mood and free time blocks."""
 
 # pylint: disable=duplicate-code
 
@@ -21,7 +21,7 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 parser = argparse.ArgumentParser(
-    description="Record today's energy, mood and free hours"
+    description="Record today's energy, mood and free time blocks"
 )
 parser.add_argument("energy", type=int, choices=range(1, 6), help="Energy level 1-5")
 parser.add_argument(
@@ -31,19 +31,19 @@ parser.add_argument(
     help="Mood",
 )
 parser.add_argument(
-    "hours_free",
-    type=float,
-    help="Hours of free time available",
+    "time_blocks",
+    type=int,
+    help="Number of free 15-minute blocks available",
 )
 
 args = parser.parse_args()
 
 logger.info(
-    "CLI invoked with energy=%s mood=%s hours_free=%s",
+    "CLI invoked with energy=%s mood=%s time_blocks=%s",
     args.energy,
     args.mood,
-    args.hours_free,
+    args.time_blocks,
 )
-entry = record_entry(args.energy, args.mood, args.hours_free)
+entry = record_entry(args.energy, args.mood, args.time_blocks)
 logger.info("Recorded entry: %s", entry)
 print(f"Recorded: {entry}")

--- a/routes/energy.py
+++ b/routes/energy.py
@@ -1,4 +1,4 @@
-"""API routes for recording daily energy, mood and free time."""
+"""API routes for recording daily energy, mood and free time blocks."""
 
 # pylint: disable=duplicate-code
 
@@ -30,19 +30,19 @@ class EnergyInput(BaseModel):  # pylint: disable=too-few-public-methods
 
     energy: int
     mood: str
-    hours_free: float
+    time_blocks: int
 
 
 @router.post("/energy")
 def add_energy(data: EnergyInput):
-    """Record today's energy, mood and free time."""
+    """Record today's energy, mood and free time blocks."""
     logger.info(
-        "POST /energy energy=%s mood=%s hours_free=%s",
+        "POST /energy energy=%s mood=%s time_blocks=%s",
         data.energy,
         data.mood,
-        data.hours_free,
+        data.time_blocks,
     )
-    entry = record_entry(data.energy, data.mood, data.hours_free)
+    entry = record_entry(data.energy, data.mood, data.time_blocks)
     logger.info("Recorded entry: %s", entry)
     return entry
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,7 +34,7 @@
           <option value="Anxious">😰 Anxious</option>
           <option value="Upbeat">😃 Upbeat</option>
         </select>
-        <input id="hoursFree" type="number" step="0.25" placeholder="Hours free"
+        <input id="timeBlocks" type="number" step="1" placeholder="Time blocks free"
           class="border p-1 flex-1" />
         <button id="recordBtn" class="px-3 py-1 bg-blue-500 text-white rounded">Record</button>
       </div>
@@ -84,7 +84,7 @@ recordBtn.onclick = async () => {
   const payload = {
     energy: parseInt(document.getElementById('energy').value),
     mood: document.getElementById('mood').value,
-    hours_free: parseFloat(document.getElementById('hoursFree').value || '0')
+    time_blocks: parseInt(document.getElementById('timeBlocks').value || '0')
   };
   const res = await fetch('/energy', {
     method: 'POST',
@@ -131,7 +131,7 @@ document.getElementById('renderPrompt').onclick = async () => {
       const energyData = await energyRes.json();
       const latest = energyData[energyData.length - 1];
       if (latest && !('time_blocks' in variables)) {
-        variables.time_blocks = Math.round(latest.hours_free * 60);
+        variables.time_blocks = latest.time_blocks;
       }
     }
   } catch (e) {

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -12,22 +12,22 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from energy import record_entry, read_entries
 
 
-def test_record_entry_writes_hours_free(tmp_path: Path):
-    """Record an entry and ensure ``hours_free`` is persisted."""
+def test_record_entry_writes_time_blocks(tmp_path: Path):
+    """Record an entry and ensure ``time_blocks`` is persisted."""
     path = tmp_path / "energy.yaml"
-    entry = record_entry(3, "Focused", 2.0, path)
-    assert entry["hours_free"] == 2.0
+    entry = record_entry(3, "Focused", 2, path)
+    assert entry["time_blocks"] == 2
     entries = read_entries(path)
-    assert entries[-1]["hours_free"] == 2.0
+    assert entries[-1]["time_blocks"] == 2
 
 
 def test_record_entry_overwrites_same_day(tmp_path: Path):
     """Saving multiple times in a day replaces the previous entry."""
     path = tmp_path / "energy.yaml"
-    record_entry(3, "Focused", 2.0, path)
-    record_entry(4, "Tired", 1.0, path)
+    record_entry(3, "Focused", 2, path)
+    record_entry(4, "Tired", 1, path)
     entries = read_entries(path)
     assert len(entries) == 1
     assert entries[0]["energy"] == 4
     assert entries[0]["mood"] == "Tired"
-    assert entries[0]["hours_free"] == 1.0
+    assert entries[0]["time_blocks"] == 1


### PR DESCRIPTION
## Summary
- switch energy tracking from hours to 15 minute blocks
- adjust web interface and prompts for time blocks
- update API route and CLI script
- revise tests and docs accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886c0b0b5a48332811243c70bd9f992