### PR TITLE
Update prompt variables with mood and energy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
-The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yml` when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
+The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
 
 Record today's energy, mood and free time blocks from the command line:
 ```bash

--- a/templates/index.html
+++ b/templates/index.html
@@ -130,8 +130,16 @@ document.getElementById('renderPrompt').onclick = async () => {
     if (energyRes.ok) {
       const energyData = await energyRes.json();
       const latest = energyData[energyData.length - 1];
-      if (latest && !('time_blocks' in variables)) {
-        variables.time_blocks = latest.time_blocks;
+      if (latest) {
+        if (!('time_blocks' in variables)) {
+          variables.time_blocks = latest.time_blocks;
+        }
+        if (!('energy' in variables)) {
+          variables.energy = latest.energy;
+        }
+        if (!('mood' in variables)) {
+          variables.mood = latest.mood;
+        }
       }
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- pass energy and mood from the latest energy entry into prompt rendering
- mention this automatic injection in README

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887412e5fdc8332afbc7f109a7ce9de