### PR TITLE
Switch tasks to todo.txt format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 ## Features
 - Parse markdown project files from a configured vault directory.
 - Store project metadata and summaries in `projects.yaml`.
-- Convert parsed projects into task entries saved in `data/tasks.yml`.
+- Convert parsed projects into task entries saved in `data/todo.txt`.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
@@ -46,7 +46,7 @@ Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
-The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
+The prompts section accepts optional JSON variables and automatically injects the contents of `data/todo.txt` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
 
 Record today's energy, mood and free time blocks from the command line:
 ```bash

--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     )
     VAULT_PATH: Path = Field(DEFAULT_VAULT, env="VAULT_PATH")
     OUTPUT_PATH: Path = Field(PROJECT_ROOT / "projects.yaml", env="OUTPUT_PATH")
-    TASKS_PATH: Path = Field(PROJECT_ROOT / "data/tasks.yml", env="TASKS_PATH")
+    TASKS_PATH: Path = Field(PROJECT_ROOT / "data/todo.txt", env="TASKS_PATH")
 
     LOG_DIR: Path = Field(PROJECT_ROOT / "data", env="LOG_DIR")
     ENERGY_LOG_PATH: Path = Field(

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml
 
 from config import config
+from tasks import read_tasks
 
 TASKS_FILE = Path(config.TASKS_PATH)
 
@@ -106,12 +107,26 @@ def projects_to_tasks(projects):
     return tasks
 
 
-def save_tasks_yaml(projects, path=TASKS_FILE):
-    """Write project tasks to YAML using the tasks schema."""
+def task_to_todo_line(task: dict) -> str:
+    """Serialize a task dictionary into a todo.txt line."""
+    parts = [task.get("title", "")]
+    parts.append(f"path:{task.get('path','')}")
+    parts.append(f"area:{task.get('area','')}")
+    parts.append(f"effort:{task.get('effort','')}")
+    parts.append(f"status:{task.get('status','')}")
+    parts.append(f"energy:{task.get('energy_cost','')}")
+    if task.get("last_reviewed"):
+        parts.append(f"last_reviewed:{task['last_reviewed']}")
+    return " ".join(parts)
+
+
+def save_tasks_txt(projects, path=TASKS_FILE):
+    """Write project tasks to todo.txt using the tasks schema."""
     tasks = projects_to_tasks(projects)
     with open(path, "w", encoding="utf-8") as handle:
-        yaml.dump(tasks, handle, sort_keys=False, allow_unicode=True)
-    return tasks
+        for task in tasks:
+            handle.write(task_to_todo_line(task) + "\n")
+    return read_tasks(path)
 
 
 if __name__ == "__main__":
@@ -120,5 +135,5 @@ if __name__ == "__main__":
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         yaml.dump(all_projects, f, sort_keys=False, allow_unicode=True)
     logger.info("Wrote %d projects to %s", len(all_projects), OUTPUT_FILE)
-    save_tasks_yaml(all_projects)
+    save_tasks_txt(all_projects)
     logger.info("Wrote tasks to %s", TASKS_FILE)

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -9,7 +9,7 @@ from typing import Optional
 import yaml
 from fastapi import APIRouter, Query
 
-from parse_projects import parse_all_projects, save_tasks_yaml
+from parse_projects import parse_all_projects, save_tasks_txt
 from tasks import read_tasks
 
 from config import config
@@ -74,17 +74,17 @@ def parse_projects_endpoint():
 
 @router.post("/save-tasks")
 def save_tasks_endpoint():
-    """Parse projects and write data/tasks.yml."""
+    """Parse projects and write data/todo.txt."""
     logger.info("POST /save-tasks")
     projects = parse_all_projects()
-    tasks = save_tasks_yaml(projects, TASKS_FILE)
+    tasks = save_tasks_txt(projects, TASKS_FILE)
     logger.info("Saved %d tasks", len(tasks))
     return {"count": len(tasks)}
 
 
 @router.get("/tasks")
 def get_tasks():
-    """Return saved tasks from data/tasks.yml."""
+    """Return saved tasks from data/todo.txt."""
     logger.info("GET /tasks")
     tasks = read_tasks(TASKS_FILE)
     logger.info("Returning %d tasks", len(tasks))

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 import textwrap
-import yaml
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -116,8 +115,8 @@ def test_parse_all_projects_expands_tilde(
     assert projects[0]["title"] == "note"
 
 
-def test_save_tasks_yaml(tmp_path: Path):
-    """save_tasks_yaml should write tasks in the expected format."""
+def test_save_tasks_txt(tmp_path: Path):
+    """save_tasks_txt should write tasks in the expected format."""
     projects = [
         {
             "title": "demo",
@@ -127,15 +126,14 @@ def test_save_tasks_yaml(tmp_path: Path):
             "status": "active",
         }
     ]
-    tasks_file = tmp_path / "tasks.yml"
-    from parse_projects import save_tasks_yaml
+    tasks_file = tmp_path / "todo.txt"
+    from parse_projects import save_tasks_txt
+    from tasks import read_tasks
 
-    tasks = save_tasks_yaml(projects, tasks_file)
-    with open(tasks_file, "r", encoding="utf-8") as handle:
-        data = yaml.safe_load(handle)
+    tasks = save_tasks_txt(projects, tasks_file)
+    data = read_tasks(tasks_file)
 
     assert tasks == data
     assert data[0]["title"] == "demo"
     assert data[0]["type"] == "project"
-    assert "last_reviewed" in data[0]
-    assert data[0]["last_reviewed"] is None
+    assert data[0].get("last_reviewed") is None


### PR DESCRIPTION
## Summary
- store project tasks in todo.txt rather than YAML
- update config and routes for new path
- adjust tasks utilities to parse todo.txt
- update README and tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688746107d5c833290be2075d11067d4