### PR TITLE
Switch back to YAML tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 ## Features
 - Parse markdown project files from a configured vault directory.
 - Store project metadata and summaries in `projects.yaml`.
-- Convert parsed projects into task entries saved in `data/todo.txt`.
+- Convert parsed projects into task entries saved in `data/tasks.yaml`.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
@@ -46,7 +46,7 @@ Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
-The prompts section accepts optional JSON variables and automatically injects the contents of `data/todo.txt` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
+The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
 
 Record today's energy, mood and free time blocks from the command line:
 ```bash

--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     )
     VAULT_PATH: Path = Field(DEFAULT_VAULT, env="VAULT_PATH")
     OUTPUT_PATH: Path = Field(PROJECT_ROOT / "projects.yaml", env="OUTPUT_PATH")
-    TASKS_PATH: Path = Field(PROJECT_ROOT / "data/todo.txt", env="TASKS_PATH")
+    TASKS_PATH: Path = Field(PROJECT_ROOT / "data/tasks.yaml", env="TASKS_PATH")
 
     LOG_DIR: Path = Field(PROJECT_ROOT / "data", env="LOG_DIR")
     ENERGY_LOG_PATH: Path = Field(

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import yaml
 
 from config import config
-from tasks import read_tasks
+from tasks import write_tasks
 
 TASKS_FILE = Path(config.TASKS_PATH)
 
@@ -107,26 +107,11 @@ def projects_to_tasks(projects):
     return tasks
 
 
-def task_to_todo_line(task: dict) -> str:
-    """Serialize a task dictionary into a todo.txt line."""
-    parts = [task.get("title", "")]
-    parts.append(f"path:{task.get('path','')}")
-    parts.append(f"area:{task.get('area','')}")
-    parts.append(f"effort:{task.get('effort','')}")
-    parts.append(f"status:{task.get('status','')}")
-    parts.append(f"energy:{task.get('energy_cost','')}")
-    if task.get("last_reviewed"):
-        parts.append(f"last_reviewed:{task['last_reviewed']}")
-    return " ".join(parts)
-
-
-def save_tasks_txt(projects, path=TASKS_FILE):
-    """Write project tasks to todo.txt using the tasks schema."""
+def save_tasks_yaml(projects, path=TASKS_FILE):
+    """Write project tasks to a YAML file using the tasks schema."""
     tasks = projects_to_tasks(projects)
-    with open(path, "w", encoding="utf-8") as handle:
-        for task in tasks:
-            handle.write(task_to_todo_line(task) + "\n")
-    return read_tasks(path)
+    write_tasks(tasks, path)
+    return tasks
 
 
 if __name__ == "__main__":
@@ -135,5 +120,5 @@ if __name__ == "__main__":
     with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
         yaml.dump(all_projects, f, sort_keys=False, allow_unicode=True)
     logger.info("Wrote %d projects to %s", len(all_projects), OUTPUT_FILE)
-    save_tasks_txt(all_projects)
+    save_tasks_yaml(all_projects)
     logger.info("Wrote tasks to %s", TASKS_FILE)

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -9,7 +9,7 @@ from typing import Optional
 import yaml
 from fastapi import APIRouter, Query
 
-from parse_projects import parse_all_projects, save_tasks_txt
+from parse_projects import parse_all_projects, save_tasks_yaml
 from tasks import read_tasks
 
 from config import config
@@ -74,17 +74,17 @@ def parse_projects_endpoint():
 
 @router.post("/save-tasks")
 def save_tasks_endpoint():
-    """Parse projects and write data/todo.txt."""
+    """Parse projects and write data/tasks.yaml."""
     logger.info("POST /save-tasks")
     projects = parse_all_projects()
-    tasks = save_tasks_txt(projects, TASKS_FILE)
+    tasks = save_tasks_yaml(projects, TASKS_FILE)
     logger.info("Saved %d tasks", len(tasks))
     return {"count": len(tasks)}
 
 
 @router.get("/tasks")
 def get_tasks():
-    """Return saved tasks from data/todo.txt."""
+    """Return saved tasks from data/tasks.yaml."""
     logger.info("GET /tasks")
     tasks = read_tasks(TASKS_FILE)
     logger.info("Returning %d tasks", len(tasks))

--- a/tasks.py
+++ b/tasks.py
@@ -6,6 +6,8 @@ import logging
 from pathlib import Path
 from typing import List, Dict
 
+import yaml
+
 from config import config
 
 TASKS_FILE = Path(config.TASKS_PATH)
@@ -23,40 +25,20 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 
-def parse_todo_line(line: str) -> Dict:
-    """Convert a single todo.txt line into a task dictionary."""
-    tokens = line.strip().split()
-    task: Dict[str, str | int] = {"title": ""}
-    title_parts: List[str] = []
-    for token in tokens:
-        if token.startswith("path:"):
-            task["path"] = token.split(":", 1)[1]
-        elif token.startswith("area:"):
-            task["area"] = token.split(":", 1)[1]
-        elif token.startswith("effort:"):
-            task["effort"] = token.split(":", 1)[1]
-        elif token.startswith("status:"):
-            task["status"] = token.split(":", 1)[1]
-        elif token.startswith("energy:"):
-            task["energy_cost"] = int(token.split(":", 1)[1])
-        elif token.startswith("last_reviewed:"):
-            task["last_reviewed"] = token.split(":", 1)[1]
-        else:
-            title_parts.append(token)
-    task["title"] = " ".join(title_parts)
-    task.setdefault("type", "project")
-    task.setdefault("source", "summary")
-    return task
-
-
 def read_tasks(path: Path = TASKS_FILE) -> List[Dict]:
-    """Return all task entries from the todo.txt file."""
+    """Return all task entries from the YAML file."""
     logger.info("Reading tasks from %s", path)
     if not path.exists():
         logger.info("%s does not exist", path)
         return []
     with open(path, "r", encoding="utf-8") as handle:
-        lines = [line.strip() for line in handle if line.strip()]
-    tasks = [parse_todo_line(line) for line in lines]
+        tasks = yaml.safe_load(handle) or []
     logger.debug("Loaded %d tasks", len(tasks))
     return tasks
+
+
+def write_tasks(tasks: List[Dict], path: Path = TASKS_FILE) -> None:
+    """Write tasks to a YAML file."""
+    logger.info("Writing %d tasks to %s", len(tasks), path)
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.dump(tasks, handle, sort_keys=False, allow_unicode=True)

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -115,8 +115,8 @@ def test_parse_all_projects_expands_tilde(
     assert projects[0]["title"] == "note"
 
 
-def test_save_tasks_txt(tmp_path: Path):
-    """save_tasks_txt should write tasks in the expected format."""
+def test_save_tasks_yaml(tmp_path: Path):
+    """save_tasks_yaml should write tasks in the expected format."""
     projects = [
         {
             "title": "demo",
@@ -126,11 +126,11 @@ def test_save_tasks_txt(tmp_path: Path):
             "status": "active",
         }
     ]
-    tasks_file = tmp_path / "todo.txt"
-    from parse_projects import save_tasks_txt
+    tasks_file = tmp_path / "tasks.yaml"
+    from parse_projects import save_tasks_yaml
     from tasks import read_tasks
 
-    tasks = save_tasks_txt(projects, tasks_file)
+    tasks = save_tasks_yaml(projects, tasks_file)
     data = read_tasks(tasks_file)
 
     assert tasks == data


### PR DESCRIPTION
## Summary
- revert task storage to YAML instead of todo.txt
- update config paths and routes
- adjust README documentation
- tweak project parsing utilities
- update tests for YAML format

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875087b9ec8332ae836e78dd2f16cf