### PR TITLE
Add ChatGPT endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
 - Retrieve saved tasks through the `/tasks` API endpoint.
 - Render prompt templates via the `/render-prompt` API or the web interface.
+- Query ChatGPT via the `/ask` API endpoint.
 - Containerized setup using Docker and docker-compose.
 
 ## Setup
@@ -47,6 +48,7 @@ The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
+You can also query ChatGPT from the command line or web interface by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 
 Record today's energy, mood and free time blocks from the command line:
 ```bash

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from fastapi import FastAPI
 
-from routes import projects, energy, web
+from routes import projects, energy, web, openai_route
 from config import config
 
 LOG_FILE = Path(config.LOG_DIR) / "server.log"
@@ -25,4 +25,5 @@ app = FastAPI()
 app.include_router(projects.router)
 app.include_router(energy.router)
 app.include_router(web.router)
+app.include_router(openai_route.router)
 logger.info("Routers registered")

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,19 @@
+"""Utility functions for interacting with the OpenAI API."""
+
+from __future__ import annotations
+
+import openai
+
+from config import config
+
+
+async def ask_chatgpt(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+    """Send a prompt to OpenAI ChatGPT and return the response text."""
+    if not config.OPENAI_API_KEY:
+        raise ValueError("OPENAI_API_KEY is not configured")
+
+    client = openai.AsyncOpenAI(api_key=config.OPENAI_API_KEY)
+    chat_completion = await client.chat.completions.create(
+        model=model, messages=[{"role": "user", "content": prompt}]
+    )
+    return chat_completion.choices[0].message.content

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pyyaml==6.0.2
 fastapi==0.116.1
 uvicorn==0.35.0
 jinja2==3.1.6
+openai==1.30.1
 pytest==8.4.1
 black==25.1.0

--- a/routes/openai_route.py
+++ b/routes/openai_route.py
@@ -1,0 +1,18 @@
+"""FastAPI router for interacting with the OpenAI API."""
+
+from fastapi import APIRouter, Body
+
+from openai_client import ask_chatgpt
+
+router = APIRouter()
+
+
+@router.post("/ask")
+async def ask_endpoint(data: dict = Body(...)):
+    """Send the provided prompt to ChatGPT and return the response."""
+    prompt: str = data.get("prompt", "")
+    if not prompt:
+        return {"error": "Prompt is required"}
+
+    response = await ask_chatgpt(prompt)
+    return {"response": response}


### PR DESCRIPTION
## Summary
- add openai library
- implement OpenAI client and API route
- register new route in FastAPI app
- document `/ask` endpoint in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887527151c883328310a3612210d380