### PR TITLE
Add OpenAPI key support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+ENVIRONMENT=development
+DEBUG=true
+PORT=8000
+# OpenAI API token for ChatGPT queries
+OPENAI_API_KEY=
+# Optional key to secure API access
+OPENAPI_KEY=

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
    pip install -r requirements.txt
    ```
    All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, `jinja2`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
-3. Create a `.env` file if you need to override paths or API keys. `VAULT_PATH` defaults to `/vault/Projects` when that folder exists, otherwise `vault/Projects` relative to the project root. Paths containing `~` are expanded to your home directory.
+3. Create a `.env` file if you need to override paths or API keys. Set `OPENAI_API_KEY` for ChatGPT access and optionally `OPENAPI_KEY` to secure the API. `VAULT_PATH` defaults to `/vault/Projects` when that folder exists, otherwise `vault/Projects` relative to the project root. Paths containing `~` are expanded to your home directory.
 4. Ensure the vault directory exists and contains markdown project files.
 5. Create a `data` directory to persist logs:
    ```bash

--- a/config.py
+++ b/config.py
@@ -42,6 +42,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
 
     # === Optional tokens ===
     OPENAI_API_KEY: str = Field(default="", env="OPENAI_API_KEY")
+    OPENAPI_KEY: str = Field(default="", env="OPENAPI_KEY")
     API_KEY: str = Field(default="", env="API_KEY")
 
     model_config = SettingsConfigDict(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,6 @@ services:
       - ENVIRONMENT=development
       - DEBUG=true
       - PORT=8000
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAPI_KEY=${OPENAPI_KEY}
     command: sh -c "python parse_projects.py && uvicorn main:app --host 0.0.0.0 --port 8000"


### PR DESCRIPTION
## Summary
- support `OPENAPI_KEY` and `OPENAI_API_KEY` via docker-compose
- load `OPENAPI_KEY` in config
- document env vars in README
- provide `.env` template

## Testing
- `black --check .`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688755000c1c8332a6430c23b5a27387