### PR TITLE
Audit docs and bug tracker

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,3 +1,5 @@
 # Known Issues
 
 1. **Vault directory** - `parse_projects.py` expects a `vault/Projects` folder. If the directory does not exist the script fails.
+2. **OpenAI client not closed** - `openai_client.ask_chatgpt` instantiates `AsyncOpenAI` but never closes it which can leak connections.
+3. **Custom task path** - `tasks.write_tasks` assumes the target directory exists when given a custom path.

--- a/Mindloom Roadmap.md
+++ b/Mindloom Roadmap.md
@@ -37,10 +37,10 @@ Build the assistant core: life-area context, Obsidian integration, a structured 
   - Reflection prompt: “What went well? What to adjust?”
 
 - [ ] **FastAPI endpoints**
-  - `GET /projects`
-  - `GET /tasks`
-  - `POST /plan` (generates daily plan via GPT)
-  - `POST /goal-breakdown` (expands goal into tasks)
+  - [x] `GET /projects`
+  - [x] `GET /tasks`
+  - [ ] `POST /plan` (generates daily plan via GPT)
+  - [ ] `POST /goal-breakdown` (expands goal into tasks)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Retrieve saved tasks through the `/tasks` API endpoint.
 - Render prompt templates via the `/render-prompt` API or the web interface.
 - Query ChatGPT via the `/ask` API endpoint.
+- Record daily energy via the `/energy` API or `record_energy.py`.
 - Containerized setup using Docker and docker-compose.
 
 ## Setup
@@ -63,9 +64,12 @@ Recording again on the same day will update the existing entry instead of adding
 Pushes and pull requests run automated checks on GitHub Actions. Formatting is
 verified with **Black**, linting with Pylint and Flake8, and tests are executed
 with Pytest. To avoid CI failures, format your code locally before committing:
+
 ```bash
 black .
+pytest -q
 ```
+
 
 ## Roadmap
 See [Mindloom Roadmap.md](Mindloom%20Roadmap.md) for planned phases and upcoming features.


### PR DESCRIPTION
## Summary
- document energy API in the README
- note how to run tests locally
- mark implemented endpoints in the roadmap
- log new issues in BUGS.md

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68876002f8588332a5ea2a708f24fc2f