### PR TITLE
Expose ask endpoint in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
-The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template.
-You can also query ChatGPT from the command line or web interface by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
+The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template. Once rendered you can click **Ask** to send the prompt to ChatGPT and display the response.
+You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 
 Record today's energy, mood and free time blocks from the command line:
 ```bash

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,8 +59,10 @@
         </select>
         <textarea id="promptVars" placeholder="{\"energy\":5}" class="border p-1 flex-1"></textarea>
         <button id="renderPrompt" class="px-3 py-1 bg-blue-500 text-white rounded">Render</button>
+        <button id="askBtn" class="px-3 py-1 bg-purple-500 text-white rounded">Ask</button>
       </div>
       <pre id="promptResult" class="bg-gray-100 p-2 rounded"></pre>
+      <pre id="askResult" class="bg-gray-100 p-2 rounded"></pre>
     </section>
   </div>
 
@@ -153,6 +155,25 @@ document.getElementById('renderPrompt').onclick = async () => {
   });
   const data = await res.json();
   document.getElementById('promptResult').textContent = data.result;
+};
+
+document.getElementById('askBtn').onclick = async () => {
+  const prompt = document.getElementById('promptResult').textContent.trim();
+  if (!prompt) {
+    alert('Render a prompt first');
+    return;
+  }
+  const res = await fetch('/ask', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ prompt })
+  });
+  const data = await res.json();
+  if (data.response) {
+    document.getElementById('askResult').textContent = data.response;
+  } else {
+    document.getElementById('askResult').textContent = JSON.stringify(data);
+  }
 };
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add new Ask button to send rendered prompt to `/ask`
- display ChatGPT responses in the interface
- document Ask button in README

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688763f5aa648332a362069ca3d9d744