### PR TITLE
Consolidate API key env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
    pip install -r requirements.txt
    ```
    All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, `jinja2`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
-3. Create a `.env` file if you need to override paths or API keys. Set `OPENAI_API_KEY` for ChatGPT access and optionally `OPENAPI_KEY` to secure the API. `VAULT_PATH` defaults to `/vault/Projects` when that folder exists, otherwise `vault/Projects` relative to the project root. Paths containing `~` are expanded to your home directory.
+3. Copy `example.env` to `.env` and set `OPENAI_API_KEY` for ChatGPT access. `VAULT_PATH` defaults to `/vault/Projects` when that folder exists, otherwise `vault/Projects` relative to the project root. Paths containing `~` are expanded to your home directory.
 4. Ensure the vault directory exists and contains markdown project files.
 5. Create a `data` directory to persist logs:
    ```bash

--- a/config.py
+++ b/config.py
@@ -42,7 +42,6 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
 
     # === Optional tokens ===
     OPENAI_API_KEY: str = Field(default="", env="OPENAI_API_KEY")
-    OPENAPI_KEY: str = Field(default="", env="OPENAPI_KEY")
     API_KEY: str = Field(default="", env="API_KEY")
 
     model_config = SettingsConfigDict(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,4 @@ services:
       - DEBUG=true
       - PORT=8000
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAPI_KEY=${OPENAPI_KEY}
     command: sh -c "python parse_projects.py && uvicorn main:app --host 0.0.0.0 --port 8000"

--- a/example.env
+++ b/example.env
@@ -3,5 +3,3 @@ DEBUG=true
 PORT=8000
 # OpenAI API token for ChatGPT queries
 OPENAI_API_KEY=
-# Optional key to secure API access
-OPENAPI_KEY=


### PR DESCRIPTION
## Summary
- rename `.env` to `example.env`
- remove unused `OPENAPI_KEY` variable
- update README instructions and docker-compose

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887672c7c4c83328824de0e471e8b66