### PR TITLE
Fix openai proxy error

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -6,3 +6,4 @@
 4. **Test imports** - Added `pytest` to `requirements.txt` and reorganized `tests/test_parse_projects.py` so linting no longer reports import errors.
 5. **Prompt variables** - The web interface now includes a JSON textarea so prompts render with provided variables instead of blanks.
 6. **OpenAI client closure** - `ask_chatgpt` now uses an async context manager to close `AsyncOpenAI` and avoid connection leaks.
+7. **HTTPX compatibility** - Pinned `httpx<0.27` in `requirements.txt` to fix `AsyncClient.__init__()` errors triggered by OpenAI's proxy handling.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ fastapi==0.116.1
 uvicorn==0.35.0
 jinja2==3.1.6
 openai==1.30.1
+httpx<0.27
 pytest==8.4.1
 black==25.1.0


### PR DESCRIPTION
## Summary
- pin httpx dependency for openai compatibility
- document httpx pin in FIXED_BUGS

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68880091d3788332be149940ecca106c