### PR TITLE
Handle missing vault directory and task path

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -7,3 +7,5 @@
 5. **Prompt variables** - The web interface now includes a JSON textarea so prompts render with provided variables instead of blanks.
 6. **OpenAI client closure** - `ask_chatgpt` now uses an async context manager to close `AsyncOpenAI` and avoid connection leaks.
 7. **HTTPX compatibility** - Pinned `httpx<0.27` in `requirements.txt` to fix `AsyncClient.__init__()` errors triggered by OpenAI's proxy handling.
+8. **Vault directory** - `parse_projects.parse_all_projects` now creates the vault path and returns an empty list when it doesn't exist.
+9. **Custom task path** - `tasks.write_tasks` ensures the destination directory is created before writing.

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -79,7 +79,9 @@ def parse_all_projects(root=PROJECTS_DIR):
     root = Path(root).expanduser()
     logger.info("Scanning %s for markdown files", root)
     if not root.is_dir():
-        raise FileNotFoundError(f"{root} does not exist")
+        logger.info("%s does not exist, creating it", root)
+        root.mkdir(parents=True, exist_ok=True)
+        return []
     md_files = list(root.rglob("*.md"))
     logger.info("Found %d markdown files", len(md_files))
     projects = [parse_markdown_file(md) for md in md_files]

--- a/tasks.py
+++ b/tasks.py
@@ -40,5 +40,6 @@ def read_tasks(path: Path = TASKS_FILE) -> List[Dict]:
 def write_tasks(tasks: List[Dict], path: Path = TASKS_FILE) -> None:
     """Write tasks to a YAML file."""
     logger.info("Writing %d tasks to %s", len(tasks), path)
+    Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", encoding="utf-8") as handle:
         yaml.dump(tasks, handle, sort_keys=False, allow_unicode=True)

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -115,6 +115,16 @@ def test_parse_all_projects_expands_tilde(
     assert projects[0]["title"] == "note"
 
 
+def test_parse_all_projects_creates_missing_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """parse_all_projects should create and return [] for a missing vault."""
+    missing = tmp_path / "vault" / "Projects"
+    projects = parse_projects.parse_all_projects(missing)
+    assert projects == []
+    assert missing.is_dir()
+
+
 def test_save_tasks_yaml(tmp_path: Path):
     """save_tasks_yaml should write tasks in the expected format."""
     projects = [

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,22 @@
+"""Unit tests for the tasks utilities."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# pylint: disable=wrong-import-position, import-outside-toplevel
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tasks import write_tasks, read_tasks
+
+
+def test_write_tasks_creates_parent(tmp_path: Path):
+    """write_tasks should create missing parent directories."""
+    target = tmp_path / "sub" / "tasks.yaml"
+    data = [{"title": "demo"}]
+    write_tasks(data, target)
+    assert target.exists()
+    saved = read_tasks(target)
+    assert saved[0]["title"] == "demo"


### PR DESCRIPTION
## Summary
- make `parse_all_projects` create the vault directory and return an empty list instead of raising when the root doesn't exist
- ensure `write_tasks` creates the parent directory of the tasks file
- test new behaviours for project parsing and task writing
- document bug fixes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68888e5fac408332b532eb8b42a52c1e