### PR TITLE
Fix linter warning in test

### DIFF
--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -115,9 +115,7 @@ def test_parse_all_projects_expands_tilde(
     assert projects[0]["title"] == "note"
 
 
-def test_parse_all_projects_creates_missing_root(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_parse_all_projects_creates_missing_root(tmp_path: Path):
     """parse_all_projects should create and return [] for a missing vault."""
     missing = tmp_path / "vault" / "Projects"
     projects = parse_projects.parse_all_projects(missing)


### PR DESCRIPTION
## Summary
- remove an unused `monkeypatch` parameter from `test_parse_projects`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68888ff4f13c8332bcd96198edd46cd3