### PR TITLE
Implement planning endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Retrieve saved tasks through the `/tasks` API endpoint.
 - Render prompt templates via the `/render-prompt` API or the web interface.
 - Query ChatGPT via the `/ask` API endpoint.
+- Generate a daily plan via the `/plan` API endpoint.
+- Expand goals into tasks via the `/goal-breakdown` API endpoint.
 - Record daily energy via the `/energy` API or `record_energy.py`.
 - Containerized setup using Docker and docker-compose.
 
@@ -50,6 +52,18 @@ The service runs on `http://localhost:8000` by default.
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template. Once rendered you can click **Ask** to send the prompt to ChatGPT and display the response.
 You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
+
+Generate a daily plan using the saved tasks and latest energy entry:
+```bash
+curl -X POST http://localhost:8000/plan
+```
+
+Break down a high-level goal into actionable tasks:
+```bash
+curl -X POST http://localhost:8000/goal-breakdown \
+  -H 'Content-Type: application/json' \
+  -d '{"goal": "Write a blog post about AI"}'
+```
 
 Record today's energy, mood and free time blocks from the command line:
 ```bash

--- a/routes/openai_route.py
+++ b/routes/openai_route.py
@@ -3,6 +3,10 @@
 from fastapi import APIRouter, Body
 
 from openai_client import ask_chatgpt
+from prompt_renderer import render_prompt
+from tasks import read_tasks
+from energy import read_entries
+from config import PROJECT_ROOT
 
 router = APIRouter()
 
@@ -16,3 +20,32 @@ async def ask_endpoint(data: dict = Body(...)):
 
     response = await ask_chatgpt(prompt)
     return {"response": response}
+
+
+@router.post("/plan")
+async def plan_endpoint():
+    """Generate a daily plan using saved tasks and the latest energy log."""
+    tasks = read_tasks()
+    entries = read_entries()
+    latest = entries[-1] if entries else {}
+    variables = {
+        "tasks": tasks,
+        "energy": latest.get("energy", 3),
+        "time_blocks": latest.get("time_blocks", 0),
+    }
+    template = PROJECT_ROOT / "prompts" / "morning_planner.txt"
+    prompt = render_prompt(str(template), variables)
+    plan = await ask_chatgpt(prompt)
+    return {"plan": plan}
+
+
+@router.post("/goal-breakdown")
+async def goal_breakdown_endpoint(data: dict = Body(...)):
+    """Expand a high-level goal into actionable tasks."""
+    goal_text: str = data.get("goal", "")
+    if not goal_text:
+        return {"error": "Goal is required"}
+    template = PROJECT_ROOT / "prompts" / "task_explainer.txt"
+    prompt = render_prompt(str(template), {"goal_text": goal_text})
+    result = await ask_chatgpt(prompt)
+    return {"tasks": result}


### PR DESCRIPTION
## Summary
- add `/plan` endpoint to generate a daily plan
- add `/goal-breakdown` endpoint to expand high-level goals
- document the new API calls in README

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888910a9680833282554d69371854f1