### PR TITLE
Implement new task schema

### DIFF
--- a/Mindloom Roadmap.md
+++ b/Mindloom Roadmap.md
@@ -22,7 +22,7 @@ Build the assistant core: life-area context, Obsidian integration, a structured 
   Extract frontmatter: `status`, `area`, `effort`, `due`  
   Extract task checkboxes and summarize content
 
-[ ] **Design task schema**  
+[x] **Design task schema**
   Fields: `id`, `title`, `area`, `type`, `due`, `recurrence`, `effort`, `energy_cost`, `status`, `last_completed`, `executive_trigger?`  
   Store as `tasks.yaml`  
   _Future: add `activation_difficulty` for high-friction starts._

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Record daily energy via the `/energy` API or `record_energy.py`.
 - Containerized setup using Docker and docker-compose.
 
+## Task schema
+Tasks are stored in `data/tasks.yaml` with the following fields:
+
+- `id`
+- `title`
+- `area`
+- `type`
+- `due`
+- `recurrence`
+- `effort`
+- `energy_cost`
+- `status`
+- `last_completed`
+- `executive_trigger`
+
+_A future update will add `activation_difficulty` for high-friction starts._
+
 ## Setup
 1. Install Python 3.10+.
 2. Install dependencies with the pinned versions:

--- a/parse_projects.py
+++ b/parse_projects.py
@@ -24,7 +24,16 @@ if not logger.handlers:
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
-VALID_KEYS = {"status", "area", "effort", "due", "last_reviewed"}
+VALID_KEYS = {
+    "status",
+    "area",
+    "effort",
+    "due",
+    "recurrence",
+    "last_completed",
+    "executive_trigger",
+    "last_reviewed",
+}
 
 
 def extract_frontmatter(text):
@@ -90,21 +99,23 @@ def parse_all_projects(root=PROJECTS_DIR):
 
 
 def projects_to_tasks(projects):
-    """Convert parsed project data to task entries."""
+    """Convert parsed project data to task entries using the task schema."""
     mapping = {"low": 1, "medium": 3, "high": 5}
     tasks = []
-    for proj in projects:
+    for idx, proj in enumerate(projects, start=1):
         task = {
+            "id": idx,
             "title": proj.get("title"),
-            "type": "project",
-            "source": "summary",
-            "path": proj.get("path"),
             "area": proj.get("area", ""),
+            "type": "project",
+            "due": proj.get("due"),
+            "recurrence": proj.get("recurrence"),
             "effort": proj.get("effort", "low"),
             "energy_cost": mapping.get(proj.get("effort", "low"), 1),
             "status": proj.get("status", "active"),
+            "last_completed": proj.get("last_completed"),
+            "executive_trigger": proj.get("executive_trigger"),
         }
-        task["last_reviewed"] = proj.get("last_reviewed")
         tasks.append(task)
     return tasks
 

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -142,6 +142,7 @@ def test_save_tasks_yaml(tmp_path: Path):
     data = read_tasks(tasks_file)
 
     assert tasks == data
+    assert data[0]["id"] == 1
     assert data[0]["title"] == "demo"
     assert data[0]["type"] == "project"
-    assert data[0].get("last_reviewed") is None
+    assert data[0].get("due") is None


### PR DESCRIPTION
## Summary
- parse additional frontmatter keys for task details
- generate tasks using new schema with unique IDs
- document task schema in README
- mark roadmap item completed
- adjust tests for revised task schema

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888962d48948332b5c8aab417965dcb