### PR TITLE
Add placeholder input modes

### DIFF
--- a/Mindloom Roadmap.md
+++ b/Mindloom Roadmap.md
@@ -233,6 +233,6 @@ Make the assistant helpful even when you don’t ask, and kinder when things sli
 - Import media stats from Last.fm, Jellyfin
 - Voice mode (Whisper + TTS)
 - Memory trimming/logging for GPT
-- Flexible input capture (voice, OCR, quick log)
+- Flexible input capture (voice, OCR, quick log) – placeholder until the UI milestone is complete
 - Safe to Forget mode: guilt-free archival
 - Spark Tracker: track what energized you

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Expand goals into tasks via the `/goal-breakdown` API endpoint.
 - Record daily energy via the `/energy` API or `record_energy.py`.
 - Containerized setup using Docker and docker-compose.
+- **Planned**: flexible input modes (voice, image capture, quick log) after the UI milestone.
 
 ## Task schema
 Tasks are stored in `data/tasks.yaml` with the following fields:
@@ -31,6 +32,12 @@ Tasks are stored in `data/tasks.yaml` with the following fields:
 - `status`
 - `last_completed`
 - `executive_trigger`
+
+### Field definitions
+
+- **effort** – rough estimate of complexity or time commitment (`low`, `medium`, `high`).
+- **energy_cost** – numeric 1–5 rating of how taxing the task will be, mapped from `effort` when projects are parsed.
+- **executive_trigger** – situational cue or reminder that helps you start the task.
 
 _A future update will add `activation_difficulty` for high-friction starts._
 


### PR DESCRIPTION
## Summary
- note upcoming support for voice/image/quick-log inputs in README
- define `effort`, `energy_cost` and `executive_trigger` fields
- mark flexible input capture as post-UI in the roadmap

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e6577db88332a1424f237a7d9544