### PR TITLE
Map project checklist items to task entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 ## Features
 - Parse markdown project files from a configured vault directory.
 - Store project metadata and summaries in `projects.yaml`.
-- Convert parsed projects into task entries saved in `data/tasks.yaml`.
+- Convert each project checklist item into a task entry referencing its project
+  in `data/tasks.yaml`.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
@@ -23,6 +24,7 @@ Tasks are stored in `data/tasks.yaml` with the following fields:
 
 - `id`
 - `title`
+- `project`
 - `area`
 - `type`
 - `due`
@@ -43,6 +45,7 @@ Recurring tasks populate `next_due` and `due_today` based on the
 - **effort** – rough estimate of complexity or time commitment (`low`, `medium`, `high`).
 - **energy_cost** – numeric 1–5 rating of how taxing the task will be for the individual.
 - **executive_trigger** – tasks that are high_friction starts.
+- **project** – path of the project this task originated from.
 
 _A future update will add `activation_difficulty` for high-friction starts._
 

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -132,6 +132,7 @@ def test_save_tasks_yaml(tmp_path: Path):
             "area": "work",
             "effort": "medium",
             "status": "active",
+            "tasks": ["- [ ] First", "- [x] Second"],
         }
     ]
     tasks_file = tmp_path / "tasks.yaml"
@@ -142,7 +143,8 @@ def test_save_tasks_yaml(tmp_path: Path):
     data = read_tasks(tasks_file)
 
     assert tasks == data
+    assert len(data) == 2
     assert data[0]["id"] == 1
-    assert data[0]["title"] == "demo"
-    assert data[0]["type"] == "project"
-    assert data[0].get("due") is None
+    assert data[0]["title"] == "First"
+    assert data[0]["type"] == "task"
+    assert data[0]["project"] == "demo.md"


### PR DESCRIPTION
## Summary
- parse each markdown checkbox item into a task
- save task entries with the originating project path
- document the new `project` field in the README
- adjust tests for the updated task generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f0d165088332a2a658d29988ad18