### PR TITLE
Add daily tasks completion page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
 - Retrieve saved tasks through the `/tasks` API endpoint.
+- Mark tasks complete via the `/daily-tasks` web page.
 - Render prompt templates via the `/render-prompt` API or the web interface.
 - Query ChatGPT via the `/ask` API endpoint.
 - Generate a daily plan via the `/plan` API endpoint.
@@ -81,7 +82,7 @@ The script writes detailed logs to `data/parse_projects.log`.
 Other components log to files in the `data` directory as well.
 The service runs on `http://localhost:8000` by default.
 
-Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates.
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml` and the latest energy entry (mood and level) when rendering. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template. Once rendered you can click **Ask** to send the prompt to ChatGPT and display the response.
 You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from fastapi import FastAPI
 
-from routes import projects, energy, web, openai_route
+from routes import projects, energy, web, openai_route, tasks_page
 from config import config
 
 LOG_FILE = Path(config.LOG_DIR) / "server.log"
@@ -26,4 +26,5 @@ app.include_router(projects.router)
 app.include_router(energy.router)
 app.include_router(web.router)
 app.include_router(openai_route.router)
+app.include_router(tasks_page.router)
 logger.info("Routers registered")

--- a/routes/tasks_page.py
+++ b/routes/tasks_page.py
@@ -1,0 +1,45 @@
+"""Web page and API for daily tasks."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from config import config, PROJECT_ROOT
+from tasks import read_tasks, mark_tasks_complete
+
+router = APIRouter()
+templates = Jinja2Templates(directory=PROJECT_ROOT / "templates")
+
+LOG_FILE = Path(config.LOG_DIR) / "tasks_page.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+@router.get("/daily-tasks", response_class=HTMLResponse)
+def tasks_page(request: Request):
+    """Display today's tasks with checkboxes."""
+    logger.info("GET /daily-tasks")
+    tasks = [t for t in read_tasks() if t.get("due_today")]
+    return templates.TemplateResponse(
+        "tasks.html", {"request": request, "tasks": tasks}
+    )
+
+
+@router.post("/daily-tasks")
+def complete_tasks(task_id: List[int] = Form([])):
+    """Mark selected tasks as complete and persist updates."""
+    logger.info("POST /daily-tasks ids=%s", task_id)
+    mark_tasks_complete([int(i) for i in task_id])
+    return RedirectResponse("/daily-tasks", status_code=303)

--- a/tasks.py
+++ b/tasks.py
@@ -76,3 +76,21 @@ def write_tasks(tasks: List[Dict], path: Path = TASKS_FILE) -> None:
     Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", encoding="utf-8") as handle:
         yaml.dump(tasks, handle, sort_keys=False, allow_unicode=True)
+
+
+def mark_tasks_complete(task_ids: List[int], path: Path = TASKS_FILE) -> int:
+    """Set selected task ids to complete and update ``last_completed``."""
+    logger.info("Marking tasks complete: %s", task_ids)
+    tasks = read_tasks(path)
+    today = date.today().isoformat()
+    count = 0
+    for task in tasks:
+        if task.get("id") in task_ids:
+            task["status"] = "complete"
+            task["last_completed"] = today
+            count += 1
+        task.pop("next_due", None)
+        task.pop("due_today", None)
+    write_tasks(tasks, path)
+    logger.info("Updated %d tasks", count)
+    return count

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Today's Tasks</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <div class="max-w-xl mx-auto space-y-4">
+    <h1 class="text-2xl font-bold mb-4">Today's Tasks</h1>
+    <form method="post" class="space-y-2">
+      <ul class="space-y-1">
+        {% for t in tasks %}
+        <li>
+          <label class="flex items-center">
+            <input type="checkbox" name="task_id" value="{{ t.id }}" class="mr-2">
+            <span>{{ t.title }}</span>
+          </label>
+        </li>
+        {% endfor %}
+      </ul>
+      <button class="px-3 py-1 bg-blue-500 text-white rounded">Mark Complete</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from datetime import date, timedelta
 
-from tasks import write_tasks, read_tasks
+from tasks import write_tasks, read_tasks, mark_tasks_complete
 
 
 def test_write_tasks_creates_parent(tmp_path: Path):
@@ -44,3 +44,15 @@ def test_recurring_task_future_due(tmp_path: Path):
     result = read_tasks(target)
     assert result[0]["due_today"] is False
     assert result[0]["next_due"] != today
+
+
+def test_mark_tasks_complete(tmp_path: Path):
+    """mark_tasks_complete should update status and last_completed."""
+    path = tmp_path / "tasks.yaml"
+    tasks = [{"id": 1, "title": "demo", "status": "active"}]
+    write_tasks(tasks, path)
+    count = mark_tasks_complete([1], path)
+    updated = read_tasks(path)
+    assert count == 1
+    assert updated[0]["status"] == "complete"
+    assert updated[0]["last_completed"] == date.today().isoformat()


### PR DESCRIPTION
## Summary
- add a simple page at `/daily-tasks` that lists today's tasks
- allow marking tasks complete which updates `data/tasks.yaml`
- expose the new router and helper
- document the feature in the README
- test new task completion helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f67388d483328d898e76060cbf59