### PR TITLE
Fix tasks page to show all tasks

### DIFF
--- a/routes/tasks_page.py
+++ b/routes/tasks_page.py
@@ -31,9 +31,9 @@ if not logger.handlers:
 
 @router.get("/daily-tasks", response_class=HTMLResponse)
 def tasks_page(request: Request):
-    """Display today's tasks with checkboxes."""
+    """Display all saved tasks with checkboxes."""
     logger.info("GET /daily-tasks")
-    tasks = [t for t in read_tasks() if t.get("due_today")]
+    tasks = read_tasks()
     return templates.TemplateResponse(
         "tasks.html", {"request": request, "tasks": tasks}
     )


### PR DESCRIPTION
## Summary
- show all saved tasks on `/daily-tasks` instead of only those due today

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688909dadfec83328f3f33a36f3987b7