### PR TITLE
Fix tasks checkbox display

### DIFF
--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -13,7 +13,7 @@
         {% for t in tasks %}
         <li>
           <label class="flex items-center">
-            <input type="checkbox" name="task_id" value="{{ t.id }}" class="mr-2">
+            <input type="checkbox" name="task_id" value="{{ t.id }}" class="mr-2" {% if t.status == 'complete' %}checked{% endif %}>
             <span>{{ t.title }}</span>
           </label>
         </li>


### PR DESCRIPTION
## Summary
- show already completed tasks as checked in the daily tasks page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890d2a6598833295e5aab2c48e3cdc