### PR TITLE
Add template variable checks

### DIFF
--- a/prompt_renderer.py
+++ b/prompt_renderer.py
@@ -1,11 +1,19 @@
 """Utility for rendering Jinja templates used in the prompts."""
 
 from pathlib import Path
-from jinja2 import Template
+from jinja2 import Environment, Template, meta
 
 
 def render_prompt(template_path: str, variables: dict) -> str:
     """Return a rendered prompt given a template path and variables."""
     template_text = Path(template_path).read_text(encoding="utf-8")
-    template = Template(template_text)
+    env = Environment()
+    parsed = env.parse(template_text)
+    required = meta.find_undeclared_variables(parsed)
+    missing = required - variables.keys()
+    if missing:
+        raise KeyError(
+            f"Missing variables for {template_path}: {', '.join(sorted(missing))}"
+        )
+    template = env.from_string(template_text)
     return template.render(**variables)

--- a/tests/test_prompt_renderer.py
+++ b/tests/test_prompt_renderer.py
@@ -1,0 +1,18 @@
+import pytest
+from pathlib import Path
+
+from prompt_renderer import render_prompt
+
+
+def test_render_prompt_missing_vars(tmp_path: Path):
+    tpl = tmp_path / "demo.txt"
+    tpl.write_text("Hello {{name}} {{value}}", encoding="utf-8")
+    with pytest.raises(KeyError):
+        render_prompt(str(tpl), {"name": "John"})
+
+
+def test_render_prompt_success(tmp_path: Path):
+    tpl = tmp_path / "demo.txt"
+    tpl.write_text("Hello {{name}}", encoding="utf-8")
+    result = render_prompt(str(tpl), {"name": "Ada"})
+    assert result == "Hello Ada"


### PR DESCRIPTION
## Summary
- detect missing variables when rendering prompts
- test render_prompt variable checking

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889555cf2908332b489ad72c8e4f085