### PR TITLE
Link morning plan to daily tasks page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
 - Retrieve saved tasks through the `/tasks` API endpoint.
 - Mark tasks complete via the `/daily-tasks` web page.
+- If `data/morning_plan.txt` exists, `/daily-tasks` shows only tasks referenced
+  by the latest morning plan.
 - Render prompt templates via the `/render-prompt` API or the web interface.
 - Query ChatGPT via the `/ask` API endpoint.
 - Generate a daily plan via the `/plan` API endpoint.
@@ -90,6 +92,8 @@ Generate a daily plan using incomplete tasks and today's energy entry:
 ```bash
 curl -X POST http://localhost:8000/plan
 ```
+The response is stored in `data/morning_plan.txt` and used to filter
+`/daily-tasks`.
 
 Break down a high-level goal into actionable tasks:
 ```bash

--- a/config.py
+++ b/config.py
@@ -39,6 +39,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     ENERGY_LOG_PATH: Path = Field(
         PROJECT_ROOT / "data/energy_log.yaml", env="ENERGY_LOG_PATH"
     )
+    PLAN_PATH: Path = Field(PROJECT_ROOT / "data/morning_plan.txt", env="PLAN_PATH")
 
     # === Optional tokens ===
     OPENAI_API_KEY: str = Field(default="", env="OPENAI_API_KEY")
@@ -56,6 +57,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
         self.TASKS_PATH = self.TASKS_PATH.expanduser()
         self.LOG_DIR = self.LOG_DIR.expanduser()
         self.ENERGY_LOG_PATH = self.ENERGY_LOG_PATH.expanduser()
+        self.PLAN_PATH = self.PLAN_PATH.expanduser()
 
 
 config = Config()

--- a/planner.py
+++ b/planner.py
@@ -1,0 +1,34 @@
+"""Utilities for storing and applying the daily plan."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+from config import config, PROJECT_ROOT
+
+PLAN_PATH = Path(getattr(config, "PLAN_PATH", PROJECT_ROOT / "data/morning_plan.txt"))
+PLAN_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def read_plan(path: Path = PLAN_PATH) -> str:
+    """Return the saved morning plan text if it exists."""
+    if not path.exists():
+        return ""
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def save_plan(text: str, path: Path = PLAN_PATH) -> None:
+    """Persist the generated morning plan."""
+    Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+
+
+def filter_tasks_by_plan(tasks: List[Dict], plan_text: str | None = None) -> List[Dict]:
+    """Return only tasks whose titles appear in the plan text."""
+    if not plan_text:
+        return tasks
+    plan_lower = plan_text.lower()
+    return [t for t in tasks if str(t.get("title", "")).lower() in plan_lower]

--- a/routes/openai_route.py
+++ b/routes/openai_route.py
@@ -7,6 +7,7 @@ from openai_client import ask_chatgpt
 from prompt_renderer import render_prompt
 from tasks import read_tasks
 from energy import read_entries
+from planner import save_plan
 from config import PROJECT_ROOT
 
 router = APIRouter()
@@ -41,6 +42,7 @@ async def plan_endpoint():
     template = PROJECT_ROOT / "prompts" / "morning_planner.txt"
     prompt = render_prompt(str(template), variables)
     plan = await ask_chatgpt(prompt)
+    save_plan(plan)
     return {"plan": plan}
 
 

--- a/routes/tasks_page.py
+++ b/routes/tasks_page.py
@@ -13,6 +13,7 @@ from fastapi.templating import Jinja2Templates
 
 from config import config, PROJECT_ROOT
 from tasks import read_tasks, mark_tasks_complete
+from planner import read_plan, filter_tasks_by_plan
 
 router = APIRouter()
 templates = Jinja2Templates(directory=PROJECT_ROOT / "templates")
@@ -34,6 +35,8 @@ def tasks_page(request: Request):
     """Display all saved tasks with checkboxes."""
     logger.info("GET /daily-tasks")
     tasks = read_tasks()
+    plan_text = read_plan()
+    tasks = filter_tasks_by_plan(tasks, plan_text)
     return templates.TemplateResponse(
         "tasks.html", {"request": request, "tasks": tasks}
     )

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,25 @@
+"""Unit tests for planner utilities."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# pylint: disable=wrong-import-position, import-outside-toplevel
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from planner import save_plan, read_plan, filter_tasks_by_plan
+
+
+def test_save_and_read_plan(tmp_path: Path):
+    path = tmp_path / "plan.txt"
+    save_plan("Do things", path)
+    assert read_plan(path) == "Do things"
+
+
+def test_filter_tasks_by_plan():
+    tasks = [{"title": "Write code"}, {"title": "Exercise"}]
+    plan = "Today you should Write code and relax"
+    filtered = filter_tasks_by_plan(tasks, plan)
+    assert len(filtered) == 1
+    assert filtered[0]["title"] == "Write code"


### PR DESCRIPTION
## Summary
- store morning plan text and filter tasks
- add config for PLAN_PATH and planner utilities
- save plan in `/plan` endpoint
- filter `/daily-tasks` using saved plan
- document behaviour and add unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f5c6e53c8332ab67ceec2a8744b6