### PR TITLE
Fix pylint warnings

### DIFF
--- a/prompt_renderer.py
+++ b/prompt_renderer.py
@@ -1,7 +1,7 @@
 """Utility for rendering Jinja templates used in the prompts."""
 
 from pathlib import Path
-from jinja2 import Environment, Template, meta
+from jinja2 import Environment, meta
 
 
 def render_prompt(template_path: str, variables: dict) -> str:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -12,12 +12,14 @@ from planner import save_plan, read_plan, filter_tasks_by_plan
 
 
 def test_save_and_read_plan(tmp_path: Path):
+    """Saving then loading should return the original text."""
     path = tmp_path / "plan.txt"
     save_plan("Do things", path)
     assert read_plan(path) == "Do things"
 
 
 def test_filter_tasks_by_plan():
+    """Only tasks mentioned in the plan should be returned."""
     tasks = [{"title": "Write code"}, {"title": "Exercise"}]
     plan = "Today you should Write code and relax"
     filtered = filter_tasks_by_plan(tasks, plan)

--- a/tests/test_prompt_renderer.py
+++ b/tests/test_prompt_renderer.py
@@ -1,10 +1,13 @@
-import pytest
+"""Tests for the prompt rendering utilities."""
+
 from pathlib import Path
+import pytest
 
 from prompt_renderer import render_prompt
 
 
 def test_render_prompt_missing_vars(tmp_path: Path):
+    """Renderer should raise if required variables are absent."""
     tpl = tmp_path / "demo.txt"
     tpl.write_text("Hello {{name}} {{value}}", encoding="utf-8")
     with pytest.raises(KeyError):
@@ -12,6 +15,7 @@ def test_render_prompt_missing_vars(tmp_path: Path):
 
 
 def test_render_prompt_success(tmp_path: Path):
+    """Renderer should fill variables correctly."""
     tpl = tmp_path / "demo.txt"
     tpl.write_text("Hello {{name}}", encoding="utf-8")
     result = render_prompt(str(tpl), {"name": "Ada"})


### PR DESCRIPTION
## Summary
- remove unused Template import from prompt_renderer
- document tests and fix import order

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f9b3b174833288059ac9091b35c0