### PR TITLE
Improve morning planner flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Other components log to files in the `data/logs` directory as well.
 The service runs on `http://localhost:8000` by default.
 
 Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks.
-The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml`, a `completed_tasks` list, and the latest energy entry (mood, level and time blocks) when rendering. The **Morning Planner** template filters out completed tasks and only uses today's energy entry if available. Enter additional variables in the textarea next to the dropdown, then click **Render** to see the filled template. Once rendered you can click **Ask** to send the prompt to ChatGPT and display the response.
+The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml`, a `completed_tasks` list, and the latest energy entry. Selecting **morning_planner.txt** now renders the template automatically. Clicking **Ask** with that template chosen calls the `/plan` endpoint, writes `data/morning_plan.txt` and takes you to `/daily-tasks`. Other templates still require clicking **Render** first and **Ask** sends the prompt to ChatGPT via `/ask`.
 You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 
 Generate a daily plan using incomplete tasks and today's energy entry:

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,7 +109,7 @@ document.getElementById('loadEnergy').onclick = async () => {
   document.getElementById('energyData').textContent = JSON.stringify(data, null, 2);
 };
 
-document.getElementById('renderPrompt').onclick = async () => {
+async function renderPromptAction() {
   const select = document.getElementById('promptSelect');
   const varsText = document.getElementById('promptVars').value || '{}';
   let variables = {};
@@ -155,9 +155,31 @@ document.getElementById('renderPrompt').onclick = async () => {
   });
   const data = await res.json();
   document.getElementById('promptResult').textContent = data.result;
+}
+
+document.getElementById('renderPrompt').onclick = renderPromptAction;
+
+const promptSelect = document.getElementById('promptSelect');
+promptSelect.onchange = () => {
+  if (promptSelect.value.endsWith('morning_planner.txt')) {
+    renderPromptAction();
+  }
 };
 
 document.getElementById('askBtn').onclick = async () => {
+  const select = document.getElementById('promptSelect');
+  if (select.value.endsWith('morning_planner.txt')) {
+    const res = await fetch('/plan', { method: 'POST' });
+    const data = await res.json();
+    if (data.plan) {
+      document.getElementById('askResult').textContent = data.plan;
+    } else {
+      document.getElementById('askResult').textContent = JSON.stringify(data);
+    }
+    window.location.href = '/daily-tasks';
+    return;
+  }
+
   const prompt = document.getElementById('promptResult').textContent.trim();
   if (!prompt) {
     alert('Render a prompt first');
@@ -165,7 +187,7 @@ document.getElementById('askBtn').onclick = async () => {
   }
   const res = await fetch('/ask', {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ prompt })
   });
   const data = await res.json();


### PR DESCRIPTION
## Summary
- rework index.html JS so choosing `morning_planner.txt` auto-renders the template
- when "Ask" is clicked for the morning planner, call `/plan`, save the plan and redirect to `/daily-tasks`
- document new behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889fdb167088332bd663e0ae2c0bfc0