### PR TITLE
Add inline metadata parsing for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Store project metadata and summaries in `projects.yaml`.
 - Convert each project checklist item into a task entry referencing its project
   in `data/tasks.yaml`.
+- Parse inline `Due Date: YYYY-MM-DD` and `Recurrence: interval` markers from
+  each task line.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -148,3 +148,29 @@ def test_save_tasks_yaml(tmp_path: Path):
     assert data[0]["title"] == "First"
     assert data[0]["type"] == "task"
     assert data[0]["project"] == "demo.md"
+
+
+def test_parse_task_line_with_metadata():
+    """Inline due dates and recurrence should be parsed from each line."""
+    line = "- [ ] Demo Recurrence: weekly Due Date: 2025-01-01"
+    title, completed, due, recurrence = parse_projects._parse_task_line(line)
+    assert title == "Demo"
+    assert completed is False
+    assert due == "2025-01-01"
+    assert recurrence == "weekly"
+
+
+def test_line_overrides_frontmatter():
+    """Per-line metadata should override project frontmatter."""
+    projects = [
+        {
+            "title": "demo",
+            "path": "demo.md",
+            "due": "2025-12-31",
+            "recurrence": "monthly",
+            "tasks": ["- [ ] Task Recurrence: weekly Due Date: 2025-01-01"],
+        }
+    ]
+    tasks = parse_projects.projects_to_tasks(projects)
+    assert tasks[0]["due"] == "2025-01-01"
+    assert tasks[0]["recurrence"] == "weekly"


### PR DESCRIPTION
## Summary
- parse task list lines for `Recurrence:` and `Due Date:` markers
- make per-line metadata override project frontmatter
- document inline metadata support in README
- test parsing of inline metadata

## Testing
- `black . --quiet`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a09ea4c108332886182a1eabde2b3