### PR TITLE
Improve task matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Mark tasks complete via the `/daily-tasks` web page.
 - If `data/morning_plan.txt` exists, `/daily-tasks` shows only tasks referenced
   by the latest morning plan.
+- Task matching ignores punctuation so titles like `Check garden hose.` still
+  match the plan text.
 - Render prompt templates via the `/render-prompt` API or the web interface.
 - Query ChatGPT via the `/ask` API endpoint.
 - Generate a daily plan via the `/plan` API endpoint.

--- a/planner.py
+++ b/planner.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Dict
+import string
+
+PUNCT_TABLE = str.maketrans("", "", string.punctuation)
+
+
+def _clean(text: str) -> str:
+    """Lowercase and remove punctuation from ``text``."""
+    return text.translate(PUNCT_TABLE).lower()
+
 
 from config import config, PROJECT_ROOT
 
@@ -30,5 +39,5 @@ def filter_tasks_by_plan(tasks: List[Dict], plan_text: str | None = None) -> Lis
     """Return only tasks whose titles appear in the plan text."""
     if not plan_text:
         return tasks
-    plan_lower = plan_text.lower()
-    return [t for t in tasks if str(t.get("title", "")).lower() in plan_lower]
+    plan_clean = _clean(plan_text)
+    return [t for t in tasks if _clean(str(t.get("title", ""))) in plan_clean]

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -25,3 +25,12 @@ def test_filter_tasks_by_plan():
     filtered = filter_tasks_by_plan(tasks, plan)
     assert len(filtered) == 1
     assert filtered[0]["title"] == "Write code"
+
+
+def test_filter_tasks_ignores_punctuation():
+    """Titles should match even when the plan omits punctuation."""
+    tasks = [{"title": "Check garden hose."}, {"title": "Write code"}]
+    plan = "1. Check garden hose (home) - make sure it works"
+    filtered = filter_tasks_by_plan(tasks, plan)
+    assert len(filtered) == 1
+    assert filtered[0]["title"] == "Check garden hose."


### PR DESCRIPTION
## Summary
- ignore punctuation when matching plan text to task titles
- note new matching behavior in README
- test matching with punctuation differences

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa86db4648332952736ed4a0ced57