### PR TITLE
Add task management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
 - Retrieve saved tasks through the `/tasks` API endpoint.
 - Mark tasks complete via the `/daily-tasks` web page.
+- Edit task recurrence, due dates and completion via the `/manage-tasks` page.
 - If `data/morning_plan.txt` exists, `/daily-tasks` shows only tasks referenced
   by the latest morning plan.
 - Task matching ignores punctuation so titles like `Check garden hose.` still
@@ -88,7 +89,7 @@ The script writes detailed logs to `data/logs/parse_projects.log`.
 Other components log to files in the `data/logs` directory as well.
 The service runs on `http://localhost:8000` by default.
 
-Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks.
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks. Use `/manage-tasks` to edit due dates or recurrence settings.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml`, a `completed_tasks` list, and the latest energy entry. Selecting **morning_planner.txt** now renders the template automatically. Clicking **Ask** with that template chosen calls the `/plan` endpoint, writes `data/morning_plan.txt` and takes you to `/daily-tasks`. Other templates still require clicking **Render** first and **Ask** sends the prompt to ChatGPT via `/ask`.
 You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 

--- a/templates/manage_tasks.html
+++ b/templates/manage_tasks.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Edit Tasks</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-4">
+  <div class="max-w-3xl mx-auto space-y-4">
+    <h1 class="text-2xl font-bold mb-4">Edit Tasks</h1>
+    <form method="post" class="space-y-2">
+      <table class="min-w-full border">
+        <thead>
+          <tr class="bg-gray-100">
+            <th class="px-2 py-1 border">Title</th>
+            <th class="px-2 py-1 border">Recurrence</th>
+            <th class="px-2 py-1 border">Due Date</th>
+            <th class="px-2 py-1 border">Completed</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for t in tasks %}
+          <tr>
+            <td class="px-2 py-1 border">{{ t.title }}</td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="recurrence-{{t.id}}" value="{{ t.recurrence or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="date" name="due-{{t.id}}" value="{{ t.due or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border text-center">
+              <input type="checkbox" name="completed-{{t.id}}" {% if t.status == 'complete' %}checked{% endif %}>
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      <button class="px-3 py-1 bg-blue-500 text-white rounded">Save</button>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support editing tasks via new `/manage-tasks` page
- document the page in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b32c47d748332953f700ad8927562