### PR TITLE
Add write-tasks sync endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
+- Write modified tasks back to markdown via the `/write-tasks` API endpoint or the web interface.
 - Retrieve saved tasks through the `/tasks` API endpoint.
 - Mark tasks complete via the `/daily-tasks` web page.
 - Edit task recurrence, due dates and completion via the `/manage-tasks` page.

--- a/routes/projects.py
+++ b/routes/projects.py
@@ -9,7 +9,7 @@ from typing import Optional
 import yaml
 from fastapi import APIRouter, Query
 
-from parse_projects import parse_all_projects, save_tasks_yaml
+from parse_projects import parse_all_projects, save_tasks_yaml, write_tasks_to_projects
 from tasks import read_tasks
 
 from config import config
@@ -80,6 +80,16 @@ def save_tasks_endpoint():
     tasks = save_tasks_yaml(projects, TASKS_FILE)
     logger.info("Saved %d tasks", len(tasks))
     return {"count": len(tasks)}
+
+
+@router.post("/write-tasks")
+def write_tasks_endpoint():
+    """Write modified tasks.yaml entries back to project files."""
+    logger.info("POST /write-tasks")
+    tasks = read_tasks(TASKS_FILE)
+    count = write_tasks_to_projects(tasks, Path(config.VAULT_PATH))
+    logger.info("Updated %d project files", count)
+    return {"projects": count}
 
 
 @router.get("/tasks")

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,9 +8,11 @@
       <div class="flex gap-2">
         <button id="parseBtn" class="px-3 py-1 bg-blue-500 text-white rounded">Parse</button>
         <button id="tasksBtn" class="px-3 py-1 bg-green-500 text-white rounded">Save Tasks</button>
+        <button id="writeTasksBtn" class="px-3 py-1 bg-purple-500 text-white rounded">Write Tasks</button>
       </div>
       <pre id="parseResult" class="bg-gray-100 p-2 rounded"></pre>
       <pre id="tasksResult" class="bg-gray-100 p-2 rounded"></pre>
+      <pre id="writeTasksResult" class="bg-gray-100 p-2 rounded"></pre>
     </section>
     <section class="space-y-2">
       <h2 class="text-xl font-semibold">Record Energy</h2>
@@ -74,6 +76,13 @@ tasksBtn.onclick = async () => {
   const res = await fetch('/save-tasks', {method: 'POST'});
   const data = await res.json();
   document.getElementById('tasksResult').textContent = JSON.stringify(data);
+};
+
+const writeTasksBtn = document.getElementById('writeTasksBtn');
+writeTasksBtn.onclick = async () => {
+  const res = await fetch('/write-tasks', {method: 'POST'});
+  const data = await res.json();
+  document.getElementById('writeTasksResult').textContent = JSON.stringify(data);
 };
 
 const recordBtn = document.getElementById('recordBtn');

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -174,3 +174,33 @@ def test_line_overrides_frontmatter():
     tasks = parse_projects.projects_to_tasks(projects)
     assert tasks[0]["due"] == "2025-01-01"
     assert tasks[0]["recurrence"] == "weekly"
+
+
+def test_write_tasks_to_projects(tmp_path: Path):
+    """write_tasks_to_projects should update markdown tasks."""
+    project_dir = tmp_path / "Projects"
+    project_dir.mkdir()
+    md_file = project_dir / "demo.md"
+    md_file.write_text("- [ ] First\n- [ ] Second\n", encoding="utf-8")
+
+    tasks = [
+        {
+            "id": 1,
+            "title": "First",
+            "project": "Projects/demo.md",
+            "status": "complete",
+        },
+        {
+            "id": 2,
+            "title": "Second",
+            "project": "Projects/demo.md",
+            "recurrence": "daily",
+            "status": "active",
+        },
+    ]
+
+    parse_projects.write_tasks_to_projects(tasks, project_dir)
+
+    lines = md_file.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "- [x] First"
+    assert lines[1] == "- [ ] Second Recurrence: daily"


### PR DESCRIPTION
## Summary
- update README with new endpoint
- add `write_tasks_to_projects` utility
- support POST `/write-tasks` endpoint
- expose button on index page
- test markdown sync functionality

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b39dd28848332a1e7a5ed1957470d