### PR TITLE
Add task line documentation and writer update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Store project metadata and summaries in `projects.yaml`.
 - Convert each project checklist item into a task entry referencing its project
   in `data/tasks.yaml`.
-- Parse inline `Due Date: YYYY-MM-DD` and `Recurrence: interval` markers from
-  each task line.
+- Parse task lines using the format `- [ ] Task description | due:2025-01-01 | recur:weekly`.
 - Provide a `/projects` API endpoint with optional filters for status, area and effort.
 - Trigger project parsing via the `/parse-projects` API endpoint or the web interface.
 - Save tasks via the `/save-tasks` API endpoint or the web interface.
@@ -57,6 +56,29 @@ Recurring tasks populate `next_due` and `due_today` based on the
 - **project** – path of the project this task originated from.
 
 _A future update will add `activation_difficulty` for high-friction starts._
+
+### Markdown task line format
+Tasks in project files store optional metadata on the same line as the
+description:
+
+```
+- [ ] Example task | due:2025-08-15 | recur:weekly | effort:med | energy:2 | last:2025-07-25 | exec:high
+```
+
+Rules:
+
+- Start with `- [ ]` for incomplete or `- [x]` for completed tasks.
+- The task description comes first.
+- Metadata fields follow separated by `|` and use `key:value`.
+
+Supported keys:
+
+- `due` – due date in `YYYY-MM-DD` format
+- `recur` – recurrence rule
+- `effort` – estimated effort (`low`, `med`, `high`)
+- `energy` – energy cost from 1–5
+- `last` – date last completed
+- `exec` – executive function demand (`low`, `med`, `high`)
 
 ## Setup
 1. Install Python 3.10+.

--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -152,7 +152,7 @@ def test_save_tasks_yaml(tmp_path: Path):
 
 def test_parse_task_line_with_metadata():
     """Inline due dates and recurrence should be parsed from each line."""
-    line = "- [ ] Demo Recurrence: weekly Due Date: 2025-01-01"
+    line = "- [ ] Demo | due:2025-01-01 | recur:weekly"
     title, completed, due, recurrence = parse_projects._parse_task_line(line)
     assert title == "Demo"
     assert completed is False
@@ -168,7 +168,7 @@ def test_line_overrides_frontmatter():
             "path": "demo.md",
             "due": "2025-12-31",
             "recurrence": "monthly",
-            "tasks": ["- [ ] Task Recurrence: weekly Due Date: 2025-01-01"],
+            "tasks": ["- [ ] Task | recur:weekly | due:2025-01-01"],
         }
     ]
     tasks = parse_projects.projects_to_tasks(projects)
@@ -203,4 +203,4 @@ def test_write_tasks_to_projects(tmp_path: Path):
 
     lines = md_file.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "- [x] First"
-    assert lines[1] == "- [ ] Second Recurrence: daily"
+    assert lines[1] == "- [ ] Second | recur:daily"


### PR DESCRIPTION
## Summary
- document markdown task line format in README
- parse pipe-separated metadata from project task lines
- write tasks back to project files using the new format
- update tests for the revised syntax

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b45a2dfc88332aa9a95f018128f39