### PR TITLE
Expose all task fields on manage page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Write modified tasks back to markdown via the `/write-tasks` API endpoint or the web interface.
 - Retrieve saved tasks through the `/tasks` API endpoint.
 - Mark tasks complete via the `/daily-tasks` web page.
-- Edit task recurrence, due dates and completion via the `/manage-tasks` page.
+- Edit all task fields via the `/manage-tasks` page.
 - If `data/morning_plan.txt` exists, `/daily-tasks` shows only tasks referenced
   by the latest morning plan.
 - Task matching ignores punctuation so titles like `Check garden hose.` still
@@ -112,7 +112,7 @@ The script writes detailed logs to `data/logs/parse_projects.log`.
 Other components log to files in the `data/logs` directory as well.
 The service runs on `http://localhost:8000` by default.
 
-Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks. Use `/manage-tasks` to edit due dates or recurrence settings.
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks. Use `/manage-tasks` to edit all task fields.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml`, a `completed_tasks` list, and the latest energy entry. Selecting **morning_planner.txt** now renders the template automatically. Clicking **Ask** with that template chosen calls the `/plan` endpoint, writes `data/morning_plan.txt` and takes you to `/daily-tasks`. Other templates still require clicking **Render** first and **Ask** sends the prompt to ChatGPT via `/ask`.
 You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 

--- a/routes/tasks_page.py
+++ b/routes/tasks_page.py
@@ -66,20 +66,39 @@ async def save_tasks(request: Request):
     logger.info("POST /manage-tasks")
     form = await request.form()
     tasks = read_tasks()
+    fields = [
+        "title",
+        "project",
+        "area",
+        "type",
+        "effort",
+        "energy_cost",
+        "executive_trigger",
+        "recurrence",
+        "due",
+        "last_completed",
+        "status",
+    ]
+
     for task in tasks:
         tid = str(task.get("id"))
-        rec_key = f"recurrence-{tid}"
-        due_key = f"due-{tid}"
-        comp_key = f"completed-{tid}"
-        if rec_key in form and form[rec_key]:
-            task["recurrence"] = str(form[rec_key])
-        else:
-            task.pop("recurrence", None)
-        if due_key in form and form[due_key]:
-            task["due"] = str(form[due_key])
-        else:
-            task.pop("due", None)
-        task["status"] = "complete" if comp_key in form else "active"
+        for field in fields:
+            key = f"{field}-{tid}"
+            if key in form:
+                value = form[key]
+                if value:
+                    if field == "energy_cost":
+                        try:
+                            task[field] = int(value)
+                        except ValueError:
+                            task[field] = str(value)
+                    else:
+                        task[field] = str(value)
+                else:
+                    if field != "title":
+                        task.pop(field, None)
+                    else:
+                        task[field] = ""
         task.pop("next_due", None)
         task.pop("due_today", None)
     write_tasks(tasks)

--- a/templates/manage_tasks.html
+++ b/templates/manage_tasks.html
@@ -4,27 +4,59 @@
   <div class="max-w-3xl mx-auto space-y-4">
     <h1 class="text-2xl font-bold mb-4">Edit Tasks</h1>
     <form method="post" class="space-y-2">
-      <table class="min-w-full border">
+      <table class="min-w-full border text-sm">
         <thead>
           <tr class="bg-gray-100">
+            <th class="px-2 py-1 border">ID</th>
             <th class="px-2 py-1 border">Title</th>
+            <th class="px-2 py-1 border">Project</th>
+            <th class="px-2 py-1 border">Area</th>
+            <th class="px-2 py-1 border">Type</th>
+            <th class="px-2 py-1 border">Effort</th>
+            <th class="px-2 py-1 border">Energy</th>
+            <th class="px-2 py-1 border">Exec Trigger</th>
             <th class="px-2 py-1 border">Recurrence</th>
-            <th class="px-2 py-1 border">Due Date</th>
-            <th class="px-2 py-1 border">Completed</th>
+            <th class="px-2 py-1 border">Due</th>
+            <th class="px-2 py-1 border">Last Completed</th>
+            <th class="px-2 py-1 border">Status</th>
           </tr>
         </thead>
         <tbody>
         {% for t in tasks %}
           <tr>
-            <td class="px-2 py-1 border">{{ t.title }}</td>
+            <td class="px-2 py-1 border">{{ t.id }}</td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="title-{{t.id}}" value="{{ t.title or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="project-{{t.id}}" value="{{ t.project or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="area-{{t.id}}" value="{{ t.area or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="type-{{t.id}}" value="{{ t.type or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="effort-{{t.id}}" value="{{ t.effort or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="energy_cost-{{t.id}}" value="{{ t.energy_cost or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="executive_trigger-{{t.id}}" value="{{ t.executive_trigger or '' }}" class="border p-1 w-full">
+            </td>
             <td class="px-2 py-1 border">
               <input type="text" name="recurrence-{{t.id}}" value="{{ t.recurrence or '' }}" class="border p-1 w-full">
             </td>
             <td class="px-2 py-1 border">
               <input type="date" name="due-{{t.id}}" value="{{ t.due or '' }}" class="border p-1 w-full">
             </td>
-            <td class="px-2 py-1 border text-center">
-              <input type="checkbox" name="completed-{{t.id}}" {% if t.status == 'complete' %}checked{% endif %}>
+            <td class="px-2 py-1 border">
+              <input type="date" name="last_completed-{{t.id}}" value="{{ t.last_completed or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="status-{{t.id}}" value="{{ t.status or '' }}" class="border p-1 w-full">
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- allow editing every task schema field from the `/manage-tasks` page
- store edited values in `tasks.yaml`
- document that all fields can be modified

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b4a0a8e908332a6ad5570c926949e