### PR TITLE
Refactor task writers and clean imports

### DIFF
--- a/parse_projects.py
+++ b/parse_projects.py
@@ -155,6 +155,30 @@ def save_tasks_yaml(projects, path=TASKS_FILE):
     return tasks
 
 
+META_KEYS = {
+    "due": "due",
+    "recurrence": "recur",
+    "effort": "effort",
+    "energy_cost": "energy",
+    "last_completed": "last",
+    "executive_trigger": "exec",
+}
+
+
+def _task_to_line(task: Dict) -> str:
+    """Return the markdown representation of a task."""
+    line = "- [x] " if task.get("status") == "complete" else "- [ ] "
+    line += task.get("title", "")
+    meta = [
+        f"{label}:{task[field]}"
+        for field, label in META_KEYS.items()
+        if task.get(field)
+    ]
+    if meta:
+        line += " | " + " | ".join(meta)
+    return line
+
+
 def write_tasks_to_projects(tasks, root=PROJECTS_DIR):
     """Update markdown checklists based on tasks.yaml."""
     root = Path(root).expanduser()
@@ -178,25 +202,7 @@ def write_tasks_to_projects(tasks, root=PROJECTS_DIR):
         new_lines: List[str] = []
         for line in lines:
             if re.match(r"\s*- \[[ xX]\] ", line) and idx < len(items):
-                t = items[idx]
-                text = "- [x] " if t.get("status") == "complete" else "- [ ] "
-                text += t.get("title", "")
-                meta = []
-                if t.get("due"):
-                    meta.append(f"due:{t['due']}")
-                if t.get("recurrence"):
-                    meta.append(f"recur:{t['recurrence']}")
-                if t.get("effort"):
-                    meta.append(f"effort:{t['effort']}")
-                if t.get("energy_cost"):
-                    meta.append(f"energy:{t['energy_cost']}")
-                if t.get("last_completed"):
-                    meta.append(f"last:{t['last_completed']}")
-                if t.get("executive_trigger"):
-                    meta.append(f"exec:{t['executive_trigger']}")
-                if meta:
-                    text += " | " + " | ".join(meta)
-                new_lines.append(text)
+                new_lines.append(_task_to_line(items[idx]))
                 idx += 1
             elif re.match(r"\s*- \[[ xX]\] ", line):
                 # skip leftover task lines beyond the yaml list
@@ -205,24 +211,7 @@ def write_tasks_to_projects(tasks, root=PROJECTS_DIR):
                 new_lines.append(line)
 
         for t in items[idx:]:
-            text = "- [x] " if t.get("status") == "complete" else "- [ ] "
-            text += t.get("title", "")
-            meta = []
-            if t.get("due"):
-                meta.append(f"due:{t['due']}")
-            if t.get("recurrence"):
-                meta.append(f"recur:{t['recurrence']}")
-            if t.get("effort"):
-                meta.append(f"effort:{t['effort']}")
-            if t.get("energy_cost"):
-                meta.append(f"energy:{t['energy_cost']}")
-            if t.get("last_completed"):
-                meta.append(f"last:{t['last_completed']}")
-            if t.get("executive_trigger"):
-                meta.append(f"exec:{t['executive_trigger']}")
-            if meta:
-                text += " | " + " | ".join(meta)
-            new_lines.append(text)
+            new_lines.append(_task_to_line(t))
 
         with open(filepath, "w", encoding="utf-8") as handle:
             handle.write("\n".join(new_lines) + "\n")

--- a/planner.py
+++ b/planner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Dict
 import string
+from config import config, PROJECT_ROOT
 
 PUNCT_TABLE = str.maketrans("", "", string.punctuation)
 
@@ -13,8 +14,6 @@ def _clean(text: str) -> str:
     """Lowercase and remove punctuation from ``text``."""
     return text.translate(PUNCT_TABLE).lower()
 
-
-from config import config, PROJECT_ROOT
 
 PLAN_PATH = Path(getattr(config, "PLAN_PATH", PROJECT_ROOT / "data/morning_plan.txt"))
 PLAN_PATH.parent.mkdir(parents=True, exist_ok=True)

--- a/routes/tasks_page.py
+++ b/routes/tasks_page.py
@@ -80,25 +80,26 @@ async def save_tasks(request: Request):
         "status",
     ]
 
+    def _update_field(task: dict, field: str, value: str | None) -> None:
+        if value:
+            if field == "energy_cost":
+                try:
+                    task[field] = int(value)
+                except ValueError:
+                    task[field] = str(value)
+            else:
+                task[field] = str(value)
+        else:
+            if field != "title":
+                task.pop(field, None)
+            else:
+                task[field] = ""
+
     for task in tasks:
         tid = str(task.get("id"))
         for field in fields:
             key = f"{field}-{tid}"
-            if key in form:
-                value = form[key]
-                if value:
-                    if field == "energy_cost":
-                        try:
-                            task[field] = int(value)
-                        except ValueError:
-                            task[field] = str(value)
-                    else:
-                        task[field] = str(value)
-                else:
-                    if field != "title":
-                        task.pop(field, None)
-                    else:
-                        task[field] = ""
+            _update_field(task, field, form.get(key))
         task.pop("next_due", None)
         task.pop("due_today", None)
     write_tasks(tasks)


### PR DESCRIPTION
## Summary
- deduplicate task markdown formatting
- simplify saving form fields
- move planner config import to the top

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4bc1c0708332916b7ee40db5766e