### PR TITLE
Fix Pylint protected-access warning in tests

### DIFF
--- a/tests/test_parse_projects.py
+++ b/tests/test_parse_projects.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-# pylint: disable=wrong-import-position, duplicate-code, import-outside-toplevel, reimported
+# pylint: disable=wrong-import-position, duplicate-code, import-outside-toplevel, reimported, protected-access
 
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- disable `protected-access` in `test_parse_projects`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4d08e52c8332a4a66cb499c5b332