### PR TITLE
Improve manage tasks UI

### DIFF
--- a/routes/tasks_page.py
+++ b/routes/tasks_page.py
@@ -55,8 +55,16 @@ def manage_tasks_page(request: Request):
     """Display editable list of all tasks."""
     logger.info("GET /manage-tasks")
     tasks = read_tasks()
+    projects = sorted({t.get("project") for t in tasks if t.get("project")})
+    areas = sorted({t.get("area") for t in tasks if t.get("area")})
     return templates.TemplateResponse(
-        "manage_tasks.html", {"request": request, "tasks": tasks}
+        "manage_tasks.html",
+        {
+            "request": request,
+            "tasks": tasks,
+            "project_options": projects,
+            "area_options": areas,
+        },
     )
 
 

--- a/templates/manage_tasks.html
+++ b/templates/manage_tasks.html
@@ -4,11 +4,14 @@
   <div class="max-w-3xl mx-auto space-y-4">
     <h1 class="text-2xl font-bold mb-4">Edit Tasks</h1>
     <form method="post" class="space-y-2">
+      <div class="overflow-x-auto">
       <table class="min-w-full border text-sm">
         <thead>
           <tr class="bg-gray-100">
             <th class="px-2 py-1 border">ID</th>
             <th class="px-2 py-1 border">Title</th>
+            <th class="px-2 py-1 border">Status</th>
+            <th class="px-2 py-1 border">Due</th>
             <th class="px-2 py-1 border">Project</th>
             <th class="px-2 py-1 border">Area</th>
             <th class="px-2 py-1 border">Type</th>
@@ -16,9 +19,7 @@
             <th class="px-2 py-1 border">Energy</th>
             <th class="px-2 py-1 border">Exec Trigger</th>
             <th class="px-2 py-1 border">Recurrence</th>
-            <th class="px-2 py-1 border">Due</th>
             <th class="px-2 py-1 border">Last Completed</th>
-            <th class="px-2 py-1 border">Status</th>
           </tr>
         </thead>
         <tbody>
@@ -29,40 +30,70 @@
               <input type="text" name="title-{{t.id}}" value="{{ t.title or '' }}" class="border p-1 w-full">
             </td>
             <td class="px-2 py-1 border">
-              <input type="text" name="project-{{t.id}}" value="{{ t.project or '' }}" class="border p-1 w-full">
-            </td>
-            <td class="px-2 py-1 border">
-              <input type="text" name="area-{{t.id}}" value="{{ t.area or '' }}" class="border p-1 w-full">
-            </td>
-            <td class="px-2 py-1 border">
-              <input type="text" name="type-{{t.id}}" value="{{ t.type or '' }}" class="border p-1 w-full">
-            </td>
-            <td class="px-2 py-1 border">
-              <input type="text" name="effort-{{t.id}}" value="{{ t.effort or '' }}" class="border p-1 w-full">
-            </td>
-            <td class="px-2 py-1 border">
-              <input type="text" name="energy_cost-{{t.id}}" value="{{ t.energy_cost or '' }}" class="border p-1 w-full">
-            </td>
-            <td class="px-2 py-1 border">
-              <input type="text" name="executive_trigger-{{t.id}}" value="{{ t.executive_trigger or '' }}" class="border p-1 w-full">
-            </td>
-            <td class="px-2 py-1 border">
-              <input type="text" name="recurrence-{{t.id}}" value="{{ t.recurrence or '' }}" class="border p-1 w-full">
+              <select name="status-{{t.id}}" class="border p-1 w-full">
+                {% for opt in ["active", "complete"] %}
+                  <option value="{{ opt }}" {% if t.status == opt %}selected{% endif %}>{{ opt }}</option>
+                {% endfor %}
+              </select>
             </td>
             <td class="px-2 py-1 border">
               <input type="date" name="due-{{t.id}}" value="{{ t.due or '' }}" class="border p-1 w-full">
             </td>
             <td class="px-2 py-1 border">
-              <input type="date" name="last_completed-{{t.id}}" value="{{ t.last_completed or '' }}" class="border p-1 w-full">
+              <input type="text" name="project-{{t.id}}" value="{{ t.project or '' }}" list="projects" class="border p-1 w-full">
             </td>
             <td class="px-2 py-1 border">
-              <input type="text" name="status-{{t.id}}" value="{{ t.status or '' }}" class="border p-1 w-full">
+              <input type="text" name="area-{{t.id}}" value="{{ t.area or '' }}" list="areas" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="text" name="type-{{t.id}}" value="{{ t.type or '' }}" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <select name="effort-{{t.id}}" class="border p-1 w-full">
+                {% for opt in ["low", "medium", "high"] %}
+                  <option value="{{ opt }}" {% if t.effort == opt %}selected{% endif %}>{{ opt }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="number" name="energy_cost-{{t.id}}" value="{{ t.energy_cost or '' }}" min="1" max="5" class="border p-1 w-full">
+            </td>
+            <td class="px-2 py-1 border">
+              <select name="executive_trigger-{{t.id}}" class="border p-1 w-full">
+                {% for opt in ["low", "medium", "high"] %}
+                  <option value="{{ opt }}" {% if t.executive_trigger == opt %}selected{% endif %}>{{ opt }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td class="px-2 py-1 border">
+              <select name="recurrence-{{t.id}}" class="border p-1 w-full">
+                <option value="" {% if not t.recurrence %}selected{% endif %}></option>
+                {% for opt in ["daily", "weekly", "monthly", "yearly"] %}
+                  <option value="{{ opt }}" {% if t.recurrence == opt %}selected{% endif %}>{{ opt }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td class="px-2 py-1 border">
+              <input type="date" name="last_completed-{{t.id}}" value="{{ t.last_completed or '' }}" class="border p-1 w-full">
             </td>
           </tr>
         {% endfor %}
         </tbody>
-      </table>
-      <button class="px-3 py-1 bg-blue-500 text-white rounded">Save</button>
-    </form>
-  </div>
+        </table>
+        </div>
+        <div class="text-right sticky bottom-0 bg-white py-2">
+          <button class="px-3 py-1 bg-blue-500 text-white rounded">Save</button>
+        </div>
+        <datalist id="projects">
+          {% for p in project_options %}
+            <option value="{{ p }}">
+          {% endfor %}
+        </datalist>
+        <datalist id="areas">
+          {% for a in area_options %}
+            <option value="{{ a }}">
+          {% endfor %}
+        </datalist>
+      </form>
+    </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add project & area options for datalists
- allow enumerated dropdowns in manage tasks
- make manage tasks table scrollable

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b51b9770c8332b57ce3d6efd7e4f2