### PR TITLE
Fix morning planner task filter

### DIFF
--- a/routes/openai_route.py
+++ b/routes/openai_route.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Body
 
 from openai_client import ask_chatgpt
 from prompt_renderer import render_prompt
-from tasks import read_tasks, due_within
+from tasks import upcoming_tasks
 from energy import read_entries
 from planner import save_plan
 from config import PROJECT_ROOT
@@ -27,8 +27,7 @@ async def ask_endpoint(data: dict = Body(...)):
 @router.post("/plan")
 async def plan_endpoint():
     """Generate a daily plan using incomplete tasks and today's energy log."""
-    tasks = [t for t in read_tasks() if t.get("status") != "complete"]
-    tasks = due_within(tasks, days=7)
+    tasks = upcoming_tasks()
     entries = read_entries()
     today = date.today().isoformat()
     today_entry = next(

--- a/routes/web.py
+++ b/routes/web.py
@@ -12,7 +12,7 @@ from fastapi.templating import Jinja2Templates
 
 from config import config, PROJECT_ROOT
 from prompt_renderer import render_prompt
-from tasks import read_tasks, due_within
+from tasks import read_tasks, upcoming_tasks
 from energy import read_entries
 
 
@@ -56,7 +56,7 @@ def render_prompt_endpoint(data: dict = Body(...)):
     completed = [t for t in tasks if t.get("status") == "complete"]
     is_morning = Path(template_name).name == "morning_planner.txt"
     if is_morning:
-        tasks = due_within([t for t in tasks if t.get("status") != "complete"], days=7)
+        tasks = upcoming_tasks()
 
     if "tasks" not in variables:
         variables["tasks"] = tasks

--- a/tasks.py
+++ b/tasks.py
@@ -120,3 +120,13 @@ def due_within(
         if due_date <= limit:
             results.append(task)
     return results
+
+
+def upcoming_tasks(
+    path: Path = TASKS_FILE,
+    days: int = 7,
+    today: date | None = None,
+) -> List[Dict]:
+    """Return incomplete tasks overdue or due soon."""
+    tasks = [t for t in read_tasks(path) if t.get("status") != "complete"]
+    return due_within(tasks, days=days, today=today)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -11,7 +11,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from datetime import date, timedelta
 
-from tasks import write_tasks, read_tasks, mark_tasks_complete, due_within
+from tasks import (
+    write_tasks,
+    read_tasks,
+    mark_tasks_complete,
+    due_within,
+    upcoming_tasks,
+)
 
 
 def test_write_tasks_creates_parent(tmp_path: Path):
@@ -86,3 +92,20 @@ def test_due_within(tmp_path: Path):
     assert "soon" in titles
     assert "later" not in titles
     assert "nodate" not in titles
+
+
+def test_upcoming_tasks(tmp_path: Path):
+    """upcoming_tasks should return overdue or soon items only."""
+    target = tmp_path / "tasks.yaml"
+    today = date.today()
+    tasks = [
+        {"id": 1, "title": "overdue", "due": (today - timedelta(days=1)).isoformat()},
+        {"id": 2, "title": "soon", "due": (today + timedelta(days=3)).isoformat()},
+        {"id": 3, "title": "later", "due": (today + timedelta(days=10)).isoformat()},
+    ]
+    write_tasks(tasks, target)
+    result = upcoming_tasks(target, days=7, today=today)
+    titles = [t["title"] for t in result]
+    assert "overdue" in titles
+    assert "soon" in titles
+    assert "later" not in titles


### PR DESCRIPTION
## Summary
- ensure morning planner only includes upcoming tasks
- add helper `upcoming_tasks`
- test new helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba3383dbc8332981ca10e2619df86