### PR TITLE
Fix morning planner filtering

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -9,3 +9,4 @@
 7. **HTTPX compatibility** - Pinned `httpx<0.27` in `requirements.txt` to fix `AsyncClient.__init__()` errors triggered by OpenAI's proxy handling.
 8. **Vault directory** - `parse_projects.parse_all_projects` now creates the vault path and returns an empty list when it doesn't exist.
 9. **Custom task path** - `tasks.write_tasks` ensures the destination directory is created before writing.
+10. **Morning planner tasks** - `index.html` no longer sends the full task list when rendering `morning_planner.txt`, so the backend injects only overdue or soon-due items.

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,7 +126,10 @@ async function renderPromptAction() {
   try {
     const tasksRes = await fetch('/tasks');
     if (tasksRes.ok) {
-      variables.tasks = await tasksRes.json();
+      const tasksData = await tasksRes.json();
+      if (!select.value.endsWith('morning_planner.txt')) {
+        variables.tasks = tasksData;
+      }
     }
   } catch (e) {
     console.error('Failed to load tasks', e);


### PR DESCRIPTION
## Summary
- stop injecting all tasks when rendering `morning_planner.txt`
- document the fix in `FIXED_BUGS.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bab853a3c833282b698cf2aa845d5