### PR TITLE
Add GPT task reasons

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Dict
+import re
 import string
 from config import config, PROJECT_ROOT
 
@@ -40,3 +41,20 @@ def filter_tasks_by_plan(tasks: List[Dict], plan_text: str | None = None) -> Lis
         return tasks
     plan_clean = _clean(plan_text)
     return [t for t in tasks if _clean(str(t.get("title", ""))) in plan_clean]
+
+
+def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
+    """Return a mapping of cleaned task titles to GPT-provided reasons."""
+    reasons: Dict[str, str] = {}
+    pattern = re.compile(r"^\s*(?:\d+\.?|[-*])\s*(.+?)(?:\s*[-:\u2013]\s*(.+))?$")
+    for line in plan_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        match = pattern.match(line)
+        if not match:
+            continue
+        title = match.group(1).strip()
+        reason = (match.group(2) or "").strip()
+        reasons[_clean(title)] = reason
+    return reasons

--- a/routes/tasks_page.py
+++ b/routes/tasks_page.py
@@ -13,7 +13,7 @@ from fastapi.templating import Jinja2Templates
 
 from config import config, PROJECT_ROOT
 from tasks import read_tasks, write_tasks, mark_tasks_complete
-from planner import read_plan, filter_tasks_by_plan
+from planner import read_plan, filter_tasks_by_plan, parse_plan_reasons, _clean
 
 router = APIRouter()
 templates = Jinja2Templates(directory=PROJECT_ROOT / "templates")
@@ -36,7 +36,10 @@ def tasks_page(request: Request):
     logger.info("GET /daily-tasks")
     tasks = read_tasks()
     plan_text = read_plan()
+    reasons = parse_plan_reasons(plan_text)
     tasks = filter_tasks_by_plan(tasks, plan_text)
+    for task in tasks:
+        task["reason"] = reasons.get(_clean(str(task.get("title", ""))), "")
     return templates.TemplateResponse(
         "tasks.html", {"request": request, "tasks": tasks}
     )

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -11,6 +11,9 @@
             <input type="checkbox" name="task_id" value="{{ t.id }}" class="mr-2" {% if t.status == 'complete' %}checked{% endif %}>
             <span>{{ t.title }}</span>
           </label>
+          {% if t.reason %}
+          <p class="ml-6 text-sm text-gray-600">{{ t.reason }}</p>
+          {% endif %}
         </li>
         {% endfor %}
       </ul>

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -8,7 +8,7 @@ from pathlib import Path
 # pylint: disable=wrong-import-position, import-outside-toplevel
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from planner import save_plan, read_plan, filter_tasks_by_plan
+from planner import save_plan, read_plan, filter_tasks_by_plan, parse_plan_reasons
 
 
 def test_save_and_read_plan(tmp_path: Path):
@@ -34,3 +34,11 @@ def test_filter_tasks_ignores_punctuation():
     filtered = filter_tasks_by_plan(tasks, plan)
     assert len(filtered) == 1
     assert filtered[0]["title"] == "Check garden hose."
+
+
+def test_parse_plan_reasons():
+    """parse_plan_reasons should map titles to explanations."""
+    text = "1. Write code - finish feature\n2. Exercise - stay healthy"
+    reasons = parse_plan_reasons(text)
+    assert reasons["write code"] == "finish feature"
+    assert reasons["exercise"] == "stay healthy"


### PR DESCRIPTION
## Summary
- parse task explanations from the daily plan
- show each task's reason on the daily tasks page
- test plan parsing logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688baf1b59c083328c4ed4163ad156ad