### PR TITLE
Fix plan reason regex

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -46,7 +46,9 @@ def filter_tasks_by_plan(tasks: List[Dict], plan_text: str | None = None) -> Lis
 def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
     """Return a mapping of cleaned task titles to GPT-provided reasons."""
     reasons: Dict[str, str] = {}
-    pattern = re.compile(r"^\s*(?:\d+\.?|[-*])\s*(.+?)(?:\s*[-:\u2013]\s*(.+))?$")
+    pattern = re.compile(
+        r"^\s*(?:\d+[.)]?|[-*])\s*(.+?)(?:\s*[-:\u2013\u2014]\s*(.+))?$"
+    )
     for line in plan_text.splitlines():
         line = line.strip()
         if not line:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -42,3 +42,11 @@ def test_parse_plan_reasons():
     reasons = parse_plan_reasons(text)
     assert reasons["write code"] == "finish feature"
     assert reasons["exercise"] == "stay healthy"
+
+
+def test_parse_plan_reasons_em_dash_and_parenthesis():
+    """parse_plan_reasons should handle em dashes and numbered parentheses."""
+    text = "1) Write code — finish feature\n- Exercise: stay healthy"
+    reasons = parse_plan_reasons(text)
+    assert reasons["write code"] == "finish feature"
+    assert reasons["exercise"] == "stay healthy"


### PR DESCRIPTION
## Summary
- handle em dashes and `1)` style numbering when parsing morning plan reasons
- test new cases in planner unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688befb64b508332af4c6182f41cdbde