### PR TITLE
Fix bullet plan reasons

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -47,7 +47,7 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
     """Return a mapping of cleaned task titles to GPT-provided reasons."""
     reasons: Dict[str, str] = {}
     pattern = re.compile(
-        r"^\s*(?:\d+[.)]?|[-*])\s*(.+?)(?:\s*[-:\u2013\u2014]\s*(.+))?$"
+        r"^\s*(?:\d+[.)]?|[-*\u2022])\s*(.+?)(?:\s*[-:\u2013\u2014]\s*(.+))?$"
     )
     for line in plan_text.splitlines():
         line = line.strip()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -50,3 +50,11 @@ def test_parse_plan_reasons_em_dash_and_parenthesis():
     reasons = parse_plan_reasons(text)
     assert reasons["write code"] == "finish feature"
     assert reasons["exercise"] == "stay healthy"
+
+
+def test_parse_plan_reasons_bullet_char():
+    """parse_plan_reasons should parse lines starting with a bullet character."""
+    text = "\u2022 Write code - finish feature\n* Exercise - stay healthy"
+    reasons = parse_plan_reasons(text)
+    assert reasons["write code"] == "finish feature"
+    assert reasons["exercise"] == "stay healthy"


### PR DESCRIPTION
## Summary
- handle bullet characters when parsing plan reasons
- test for bullet characters in planner

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c791628888332b0248aa3268cd5ae