### PR TITLE
Fix multi-line plan reasons

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -49,6 +49,7 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
     pattern = re.compile(
         r"^\s*(?:\d+[.)]?|[-*\u2022])\s*(.+?)(?:\s*[-:\u2013\u2014]\s*(.+))?$"
     )
+    last_title: str | None = None
     for line in plan_text.splitlines():
         line = line.strip()
         if not line:
@@ -56,7 +57,13 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
         match = pattern.match(line)
         if not match:
             continue
+        is_number = line.lstrip()[0].isdigit()
         title = match.group(1).strip()
         reason = (match.group(2) or "").strip()
-        reasons[_clean(title)] = reason
+        if not is_number and last_title and not reason:
+            if not reasons.get(last_title):
+                reasons[last_title] = title
+            continue
+        last_title = _clean(title)
+        reasons[last_title] = reason
     return reasons

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -58,3 +58,11 @@ def test_parse_plan_reasons_bullet_char():
     reasons = parse_plan_reasons(text)
     assert reasons["write code"] == "finish feature"
     assert reasons["exercise"] == "stay healthy"
+
+
+def test_parse_plan_reasons_multiline_reason():
+    """parse_plan_reasons should support reasons on the next line."""
+    text = "1. Write code\n- finish feature\n2. Exercise\n- stay healthy"
+    reasons = parse_plan_reasons(text)
+    assert reasons["write code"] == "finish feature"
+    assert reasons["exercise"] == "stay healthy"


### PR DESCRIPTION
## Summary
- support reasons on the line after each task
- test parse_plan_reasons with multiline items

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c7b1d872c8332936a9c1d23702b08