### PR TITLE
Fix plan reason parsing for tasks with metadata

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -60,6 +60,13 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
         is_number = line.lstrip()[0].isdigit()
         title = match.group(1).strip()
         reason = (match.group(2) or "").strip()
+        # handle cases like "Task (meta: value)" where the colon splits the regex
+        if title.count("(") > title.count(")") and ")" in reason:
+            split = reason.index(")")
+            title = f"{title} {reason[: split + 1]}".strip()
+            reason = reason[split + 1 :].strip()
+        # remove trailing parenthetical metadata e.g. "(effort: high)"
+        title = re.sub(r"\([^\)]*\)\s*$", "", title).strip()
         if not is_number and last_title and not reason:
             if not reasons.get(last_title):
                 reasons[last_title] = title

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -66,3 +66,12 @@ def test_parse_plan_reasons_multiline_reason():
     reasons = parse_plan_reasons(text)
     assert reasons["write code"] == "finish feature"
     assert reasons["exercise"] == "stay healthy"
+
+
+def test_parse_plan_reasons_parenthetical_metadata():
+    """Parenthetical metadata after the title should be ignored."""
+    text = (
+        "1. Flexible recurrence nudges (effort: high)\n" "- Work on flexible recurrence"
+    )
+    reasons = parse_plan_reasons(text)
+    assert reasons["flexible recurrence nudges"] == "Work on flexible recurrence"


### PR DESCRIPTION
## Summary
- handle parenthetical metadata when parsing daily plan reasons
- test parsing of titles that include metadata

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c82769c94833289aea2cb48bd7ba3