### PR TITLE
Improve plan parsing

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -53,9 +53,11 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
     split_pattern = re.compile(r"^(.+?)(?:\s*[-:\u2013\u2014]\s*(.+))?$")
     last_title: str | None = None
     last_was_number = False
+    previous_blank = False
     for line in plan_text.splitlines():
         line = line.strip()
         if not line:
+            previous_blank = True
             continue
         bullet_match = bullet_only.match(line)
         if bullet_match:
@@ -76,6 +78,13 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
                 continue
         match = pattern.match(line)
         if not match:
+            if last_title and not reasons.get(last_title) and not previous_blank:
+                reasons[last_title] = line
+            else:
+                last_title = _clean(line)
+                reasons[last_title] = ""
+            last_was_number = False
+            previous_blank = False
             continue
         is_number = line.lstrip()[0].isdigit()
         title = match.group(1).strip()
@@ -94,4 +103,5 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
         last_title = _clean(title)
         reasons[last_title] = reason
         last_was_number = is_number
+        previous_blank = False
     return reasons

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -75,3 +75,11 @@ def test_parse_plan_reasons_parenthetical_metadata():
     )
     reasons = parse_plan_reasons(text)
     assert reasons["flexible recurrence nudges"] == "Work on flexible recurrence"
+
+
+def test_parse_plan_reasons_unbulleted_lines():
+    """Lines without bullets should treat the next line as the reason."""
+    text = "Add feature A\n\nTask B.\nExplanation for B"
+    reasons = parse_plan_reasons(text)
+    assert reasons["add feature a"] == ""
+    assert reasons["task b"] == "Explanation for B"


### PR DESCRIPTION
## Summary
- handle blank lines in `parse_plan_reasons`
- add regression test for unbulleted plan output

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c8e3d62308332b7248b40db81f305