### PR TITLE
Implement energy-based task filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ curl -X POST http://localhost:8000/plan
 ```
 The response is stored in `data/morning_plan.txt` and used to filter
 `/daily-tasks`.
+Tasks with an `energy_cost` higher than your latest logged energy are removed
+before generating the plan.
 
 Break down a high-level goal into actionable tasks:
 ```bash

--- a/planner.py
+++ b/planner.py
@@ -105,3 +105,20 @@ def parse_plan_reasons(plan_text: str) -> Dict[str, str]:
         last_was_number = is_number
         previous_blank = False
     return reasons
+
+
+def filter_tasks_by_energy(tasks: List[Dict], energy: int | None) -> List[Dict]:
+    """Return tasks whose ``energy_cost`` is within the available ``energy``."""
+    if energy is None:
+        return tasks
+    filtered: List[Dict] = []
+    for task in tasks:
+        cost = task.get("energy_cost")
+        try:
+            cost_val = int(cost)
+        except (TypeError, ValueError):
+            filtered.append(task)
+            continue
+        if cost_val <= energy:
+            filtered.append(task)
+    return filtered

--- a/routes/openai_route.py
+++ b/routes/openai_route.py
@@ -7,7 +7,7 @@ from openai_client import ask_chatgpt
 from prompt_renderer import render_prompt
 from tasks import upcoming_tasks
 from energy import read_entries
-from planner import save_plan
+from planner import save_plan, filter_tasks_by_energy
 from config import PROJECT_ROOT
 
 router = APIRouter()
@@ -29,6 +29,10 @@ async def plan_endpoint():
     """Generate a daily plan using incomplete tasks and today's energy log."""
     tasks = upcoming_tasks()
     entries = read_entries()
+    latest = entries[-1] if entries else {}
+    energy_level = latest.get("energy")
+    if energy_level is not None:
+        tasks = filter_tasks_by_energy(tasks, int(energy_level))
     today = date.today().isoformat()
     today_entry = next(
         (e for e in reversed(entries) if e.get("date") == today),

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from planner import save_plan, read_plan, filter_tasks_by_plan, parse_plan_reasons
+from planner import filter_tasks_by_energy
 
 
 def test_save_and_read_plan(tmp_path: Path):
@@ -83,3 +84,14 @@ def test_parse_plan_reasons_unbulleted_lines():
     reasons = parse_plan_reasons(text)
     assert reasons["add feature a"] == ""
     assert reasons["task b"] == "Explanation for B"
+
+
+def test_filter_tasks_by_energy():
+    """Tasks exceeding available energy should be removed."""
+    tasks = [
+        {"title": "Hard", "energy_cost": 4},
+        {"title": "Easy", "energy_cost": 2},
+    ]
+    filtered = filter_tasks_by_energy(tasks, 2)
+    assert len(filtered) == 1
+    assert filtered[0]["title"] == "Easy"


### PR DESCRIPTION
## Summary
- filter tasks by comparing energy_cost to latest logged energy
- drop high cost tasks from planning endpoint when energy is low
- document energy based filtering in README
- test new filter_tasks_by_energy helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c938c66508332bd568f9a740b9b19