### PR TITLE
Add plan intensity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,17 @@ Open `http://localhost:8000/` in a browser for a simple web interface to parse p
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml`, a `completed_tasks` list, and the latest energy entry. Selecting **morning_planner.txt** now renders the template automatically. Clicking **Ask** with that template chosen calls the `/plan` endpoint, writes `data/morning_plan.txt` and takes you to `/daily-tasks`. Other templates still require clicking **Render** first and **Ask** sends the prompt to ChatGPT via `/ask`.
 You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 
-Generate a daily plan using incomplete tasks and today's energy entry:
+Generate a daily plan using incomplete tasks and today's energy entry. You can
+optionally control how many tasks are recommended by passing an `intensity`
+query parameter (`light`, `medium` or `full`):
 ```bash
-curl -X POST http://localhost:8000/plan
+curl -X POST 'http://localhost:8000/plan?intensity=full'
 ```
 The response is stored in `data/morning_plan.txt` and used to filter
 `/daily-tasks`.
 Tasks with an `energy_cost` higher than your latest logged energy are removed
-before generating the plan.
+before generating the plan. Task selection is performed with the
+`prompts/plan_intensity_selector.txt` template based on the chosen intensity.
 
 Break down a high-level goal into actionable tasks:
 ```bash

--- a/tests/test_openai_route.py
+++ b/tests/test_openai_route.py
@@ -1,0 +1,47 @@
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import routes.openai_route as openai_route
+from main import app
+
+
+def test_plan_endpoint_intensity(monkeypatch: pytest.MonkeyPatch):
+    tasks = [
+        {"title": "Task A", "energy_cost": 1},
+        {"title": "Task B", "energy_cost": 2},
+    ]
+
+    monkeypatch.setattr(openai_route, "upcoming_tasks", lambda: tasks)
+    today = date.today().isoformat()
+    monkeypatch.setattr(
+        openai_route,
+        "read_entries",
+        lambda: [{"date": today, "energy": 5, "time_blocks": 4}],
+    )
+    monkeypatch.setattr(openai_route, "save_plan", lambda plan: None)
+    monkeypatch.setattr(openai_route, "filter_tasks_by_energy", lambda t, e: t)
+
+    responses = iter(["- Task A", "Plan"])
+
+    async def fake_ask(prompt: str, model: str = "gpt-3.5-turbo"):
+        return next(responses)
+
+    captured = []
+
+    async def fake_ask_capture(prompt: str, model: str = "gpt-3.5-turbo"):
+        captured.append(prompt)
+        return await fake_ask(prompt, model)
+
+    monkeypatch.setattr(openai_route, "ask_chatgpt", fake_ask_capture)
+
+    client = TestClient(app)
+    resp = client.post("/plan?intensity=light")
+    assert resp.status_code == 200
+    assert resp.json()["plan"] == "Plan"
+    assert "light" in captured[0]


### PR DESCRIPTION
## Summary
- allow plan endpoint to accept an `intensity` query parameter
- use `plan_intensity_selector.txt` to pick tasks before generating the plan
- document intensity usage in README
- test new intensity parameter behavior

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c981603d88332bc4a09704d77e65b