### PR TITLE
Add calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Generate a daily plan via the `/plan` API endpoint.
 - Expand goals into tasks via the `/goal-breakdown` API endpoint.
 - Record daily energy via the `/energy` API or `record_energy.py`.
+- Load calendar events from `.ics` files into `data/calendar_cache.json`.
 - Containerized setup using Docker and docker-compose.
 - **Planned**: flexible input modes (voice, image capture, quick log) after the UI milestone.
 
@@ -88,6 +89,8 @@ Supported keys:
    ```
    All packages including `python-dotenv`, `pydantic`, `pydantic-settings`, `PyYAML`, `fastapi`, `uvicorn`, `python-multipart`, `jinja2`, and `pytest` are version pinned. If you see import errors like `E0401`, ensure these packages are installed by running the above command.
 3. Copy `example.env` to `.env` and set `OPENAI_API_KEY` for ChatGPT access. `VAULT_PATH` defaults to `/vault/Projects` when that folder exists, otherwise `vault/Projects` relative to the project root. Paths containing `~` are expanded to your home directory.
+   `CALENDAR_ICS_PATH` points to your exported calendar file and `TIME_ZONE` sets
+   the IANA time zone used when parsing events.
 4. Ensure the vault directory exists and contains markdown project files.
 5. Create a `data/logs` directory to persist logs:
    ```bash

--- a/calendar_integration.py
+++ b/calendar_integration.py
@@ -1,0 +1,73 @@
+"""Utilities for loading calendar events from .ics files."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import List
+from zoneinfo import ZoneInfo
+
+from ics import Calendar
+
+from config import config, PROJECT_ROOT
+
+CACHE_PATH = PROJECT_ROOT / "data/calendar_cache.json"
+ICS_PATHS = [
+    Path(p).expanduser()
+    for p in os.getenv(
+        "CALENDAR_ICS_PATH", str(PROJECT_ROOT / "data/calendar.ics")
+    ).split(os.pathsep)
+]
+TIME_ZONE = os.getenv("TIME_ZONE", getattr(config, "TIME_ZONE", "UTC"))
+
+LOG_FILE = Path(config.LOG_DIR) / "calendar.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+@dataclass
+class Event:
+    """Simple calendar event."""
+
+    summary: str
+    start: datetime
+    end: datetime
+
+
+def _read_ics_events() -> List[Event]:
+    tz = ZoneInfo(TIME_ZONE)
+    events: List[Event] = []
+    for path in ICS_PATHS:
+        if not path.exists():
+            logger.info("ICS file %s does not exist", path)
+            continue
+        logger.info("Parsing %s", path)
+        text = path.read_text(encoding="utf-8")
+        cal = Calendar(text)
+        for item in cal.events:
+            start = item.begin.to(TIME_ZONE).datetime
+            end = item.end.to(TIME_ZONE).datetime
+            events.append(Event(item.name or "", start, end))
+    return events
+
+
+def load_events(start: date, end: date) -> List[Event]:
+    """Return events between ``start`` and ``end`` inclusive."""
+    logger.info("Loading events between %s and %s", start, end)
+    events = [e for e in _read_ics_events() if start <= e.start.date() <= end]
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(CACHE_PATH, "w", encoding="utf-8") as handle:
+        json.dump([asdict(e) for e in events], handle, default=str, ensure_ascii=False)
+    logger.info("Cached %d events to %s", len(events), CACHE_PATH)
+    return events

--- a/config.py
+++ b/config.py
@@ -40,6 +40,10 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
         PROJECT_ROOT / "data/energy_log.yaml", env="ENERGY_LOG_PATH"
     )
     PLAN_PATH: Path = Field(PROJECT_ROOT / "data/morning_plan.txt", env="PLAN_PATH")
+    CALENDAR_ICS_PATH: str = Field(
+        str(PROJECT_ROOT / "data/calendar.ics"), env="CALENDAR_ICS_PATH"
+    )
+    TIME_ZONE: str = Field("UTC", env="TIME_ZONE")
 
     # === Optional tokens ===
     OPENAI_API_KEY: str = Field(default="", env="OPENAI_API_KEY")
@@ -58,6 +62,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
         self.LOG_DIR = self.LOG_DIR.expanduser()
         self.ENERGY_LOG_PATH = self.ENERGY_LOG_PATH.expanduser()
         self.PLAN_PATH = self.PLAN_PATH.expanduser()
+        self.CALENDAR_ICS_PATH = str(Path(self.CALENDAR_ICS_PATH).expanduser())
 
 
 config = Config()

--- a/example.env
+++ b/example.env
@@ -3,3 +3,5 @@ DEBUG=true
 PORT=8000
 # OpenAI API token for ChatGPT queries
 OPENAI_API_KEY=
+CALENDAR_ICS_PATH=data/calendar.ics
+TIME_ZONE=UTC

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ openai==1.30.1
 httpx<0.27
 pytest==8.4.1
 black==25.1.0
+ics==0.7.2

--- a/tests/test_calendar_integration.py
+++ b/tests/test_calendar_integration.py
@@ -1,0 +1,53 @@
+"""Tests for calendar integration module."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+def test_load_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ics = tmp_path / "cal.ics"
+    ics.write_text(
+        """BEGIN:VCALENDAR
+PRODID:-//Test//EN
+VERSION:2.0
+BEGIN:VEVENT
+UID:1
+DTSTAMP:20250101T120000Z
+DTSTART;TZID=America/New_York:20250101T090000
+DTEND;TZID=America/New_York:20250101T100000
+SUMMARY:Meeting
+END:VEVENT
+BEGIN:VEVENT
+UID:2
+DTSTAMP:20250102T120000Z
+DTSTART;TZID=America/New_York:20250102T090000
+DTEND;TZID=America/New_York:20250102T100000
+SUMMARY:Next Day
+END:VEVENT
+END:VCALENDAR""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("CALENDAR_ICS_PATH", str(ics))
+    monkeypatch.setenv("TIME_ZONE", "UTC")
+
+    import config as cfg
+
+    importlib.reload(cfg)
+    import calendar_integration as ci
+
+    importlib.reload(ci)
+
+    events = ci.load_events(date(2025, 1, 1), date(2025, 1, 1))
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.summary == "Meeting"
+    from datetime import timedelta
+
+    assert ev.start.tzinfo.utcoffset(ev.start) == timedelta(0)
+    assert ev.start.hour == 14


### PR DESCRIPTION
## Summary
- load calendar events from `.ics` files
- support timezone and calendar paths in config
- document new environment variables
- add tests for calendar event loader

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9a200f2c83328fd6d318ae09d713