### PR TITLE
Add calendar page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
   [ActivationEngine](https://github.com/EoghannIrving/ActivationEngine) is
   configured.
 - Load calendar events from `.ics` files or Google Calendar into `data/calendar_cache.json`.
+- View cached events on the `/calendar` page.
 - Containerized setup using Docker and docker-compose.
 - **Planned**: flexible input modes (voice, image capture, quick log) after the UI milestone.
 
@@ -126,7 +127,7 @@ The script writes detailed logs to `data/logs/parse_projects.log`.
 Other components log to files in the `data/logs` directory as well.
 The service runs on `http://localhost:8000` by default.
 
-Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks. Use `/manage-tasks` to edit all task fields.
+Open `http://localhost:8000/` in a browser for a simple web interface to parse projects, record energy (including free time blocks) and render prompt templates. Visit `/daily-tasks` to check off today's tasks, `/manage-tasks` to edit them and `/calendar` to view loaded events.
 The prompts section accepts optional JSON variables and automatically injects the contents of `data/tasks.yaml`, a `completed_tasks` list, and the latest energy entry. Selecting **morning_planner.txt** now renders the template automatically. Clicking **Ask** with that template chosen calls the `/plan` endpoint, writes `data/morning_plan.yaml` and takes you to `/daily-tasks`. Other templates still require clicking **Render** first and **Ask** sends the prompt to ChatGPT via `/ask`.
 You can also query ChatGPT from the command line by posting a JSON payload with a `prompt` key to the `/ask` endpoint.
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,15 @@ import logging
 from pathlib import Path
 from fastapi import FastAPI
 
-from routes import projects, energy, web, openai_route, tasks_page, activation
+from routes import (
+    projects,
+    energy,
+    web,
+    openai_route,
+    tasks_page,
+    activation,
+    calendar_page,
+)
 from config import config
 
 LOG_FILE = Path(config.LOG_DIR) / "server.log"
@@ -28,4 +36,5 @@ app.include_router(web.router)
 app.include_router(openai_route.router)
 app.include_router(tasks_page.router)
 app.include_router(activation.router)
+app.include_router(calendar_page.router)
 logger.info("Routers registered")

--- a/routes/calendar_page.py
+++ b/routes/calendar_page.py
@@ -1,0 +1,69 @@
+"""Calendar page for viewing cached events."""
+
+# pylint: disable=duplicate-code
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import List
+from datetime import datetime
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from config import config, PROJECT_ROOT
+
+CACHE_PATH = PROJECT_ROOT / "data/calendar_cache.json"
+
+router = APIRouter()
+templates = Jinja2Templates(directory=PROJECT_ROOT / "templates")
+
+LOG_FILE = Path(config.LOG_DIR) / "calendar_page.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+class Event:  # pylint: disable=too-few-public-methods
+    """Simple container for calendar events."""
+
+    def __init__(self, summary: str, start: datetime, end: datetime):
+        self.summary = summary
+        self.start = start
+        self.end = end
+
+
+def _read_cached_events() -> List[Event]:
+    if not CACHE_PATH.exists():
+        logger.info("%s does not exist", CACHE_PATH)
+        return []
+    with open(CACHE_PATH, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    events = []
+    for item in data:
+        try:
+            start = datetime.fromisoformat(item["start"])
+            end = datetime.fromisoformat(item["end"])
+            events.append(Event(item.get("summary", ""), start, end))
+        except Exception as exc:  # pragma: no cover - invalid data
+            logger.warning("Failed parsing event %s: %s", item, exc)
+    return events
+
+
+@router.get("/calendar", response_class=HTMLResponse)
+def calendar_page(request: Request):
+    """Display events loaded from the calendar cache."""
+    logger.info("GET /calendar")
+    events = sorted(_read_cached_events(), key=lambda e: e.start)
+    return templates.TemplateResponse(
+        "calendar.html", {"request": request, "events": events}
+    )

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,7 @@
       <li><a href="/" class="hover:underline">Home</a></li>
       <li><a href="/daily-tasks" class="hover:underline">Today's Tasks</a></li>
       <li><a href="/manage-tasks" class="hover:underline">Manage Tasks</a></li>
+      <li><a href="/calendar" class="hover:underline">Calendar</a></li>
     </ul>
   </nav>
   {% block content %}{% endblock %}

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Calendar{% endblock %}
+{% block content %}
+  <div class="max-w-xl mx-auto space-y-4">
+    <h1 class="text-2xl font-bold mb-4">Calendar Events</h1>
+    {% if events %}
+    <ul class="space-y-2">
+      {% for e in events %}
+      <li>
+        <span class="font-semibold">{{ e.start.strftime('%Y-%m-%d %H:%M') }}</span>
+        -
+        <span>{{ e.end.strftime('%H:%M') }}</span>
+        : {{ e.summary }}
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p>No events loaded.</p>
+    {% endif %}
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- show cached calendar events on a new `/calendar` page
- link to the calendar in base navigation
- register the calendar router
- document the `/calendar` page in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2ddc1d6c8332970d33bb37ca25b8