### PR TITLE
Add calendar info to /plan endpoint

### DIFF
--- a/prompts/morning_planner.txt
+++ b/prompts/morning_planner.txt
@@ -3,6 +3,7 @@ You are a helpful planning assistant. The user is trying to balance sustainable 
 **Context:**
 - Energy: {{energy}} / 5
 - Free time: {{time_blocks}} blocks (15 minutes each)
+- Busy blocks: {{calendar}}
 
 **Task list:**
 {% for task in tasks %}

--- a/tests/test_openai_route.py
+++ b/tests/test_openai_route.py
@@ -26,6 +26,7 @@ def test_plan_endpoint_intensity(monkeypatch: pytest.MonkeyPatch):
     )
     monkeypatch.setattr(openai_route, "save_plan", lambda plan: None)
     monkeypatch.setattr(openai_route, "filter_tasks_by_energy", lambda t, e: t)
+    monkeypatch.setattr(openai_route, "load_events", lambda s, e: [])
 
     responses = iter(["- Task A", "Plan"])
 


### PR DESCRIPTION
## Summary
- inject busy calendar blocks when generating morning plan
- accept calendar context in `morning_planner.txt`
- mock calendar events in `test_openai_route`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d4534122c833281190d1f31e913ef