### PR TITLE
feat: refresh calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Mindloom is an offline-first personal assistant aimed at organizing projects and
 - Request a single task suggestion via the `/suggest-task` endpoint when
   [ActivationEngine](https://github.com/EoghannIrving/ActivationEngine) is
   configured.
-- Load calendar events from `.ics` files or Google Calendar into `data/calendar_cache.json`.
-- View cached events on the `/calendar` page.
+- Automatically pull calendar events from linked `.ics` files or Google Calendar when visiting the `/calendar` page, caching them in `data/calendar_cache.json`.
 - Containerized setup using Docker and docker-compose.
 - **Planned**: flexible input modes (voice, image capture, quick log) after the UI milestone.
 

--- a/routes/calendar_page.py
+++ b/routes/calendar_page.py
@@ -1,22 +1,19 @@
-"""Calendar page for viewing cached events."""
+"""Calendar page for viewing linked calendar events."""
 
 # pylint: disable=duplicate-code
 
 from __future__ import annotations
 
-import json
 import logging
+from datetime import date, timedelta
 from pathlib import Path
-from typing import List
-from datetime import datetime
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from calendar_integration import load_events
 from config import config, PROJECT_ROOT
-
-CACHE_PATH = PROJECT_ROOT / "data/calendar_cache.json"
 
 router = APIRouter()
 templates = Jinja2Templates(directory=PROJECT_ROOT / "templates")
@@ -33,37 +30,13 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 
-class Event:  # pylint: disable=too-few-public-methods
-    """Simple container for calendar events."""
-
-    def __init__(self, summary: str, start: datetime, end: datetime):
-        self.summary = summary
-        self.start = start
-        self.end = end
-
-
-def _read_cached_events() -> List[Event]:
-    if not CACHE_PATH.exists():
-        logger.info("%s does not exist", CACHE_PATH)
-        return []
-    with open(CACHE_PATH, "r", encoding="utf-8") as handle:
-        data = json.load(handle)
-    events = []
-    for item in data:
-        try:
-            start = datetime.fromisoformat(item["start"])
-            end = datetime.fromisoformat(item["end"])
-            events.append(Event(item.get("summary", ""), start, end))
-        except Exception as exc:  # pragma: no cover - invalid data
-            logger.warning("Failed parsing event %s: %s", item, exc)
-    return events
-
-
 @router.get("/calendar", response_class=HTMLResponse)
 def calendar_page(request: Request):
-    """Display events loaded from the calendar cache."""
+    """Display events pulled from linked calendars."""
     logger.info("GET /calendar")
-    events = sorted(_read_cached_events(), key=lambda e: e.start)
+    start = date.today()
+    end = start + timedelta(days=7)
+    events = sorted(load_events(start, end), key=lambda e: e.start)
     return templates.TemplateResponse(
         "calendar.html", {"request": request, "events": events}
     )

--- a/tests/test_calendar_page.py
+++ b/tests/test_calendar_page.py
@@ -1,0 +1,37 @@
+"""Tests for calendar page route automatically loading calendars."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import routes.calendar_page as cp
+
+
+def test_calendar_page_loads_linked_calendars(monkeypatch):
+    """GET /calendar should trigger load_events and display results."""
+
+    called = {}
+
+    def fake_load_events(start: date, end: date):  # pragma: no cover - patched
+        called["args"] = (start, end)
+        return [
+            SimpleNamespace(
+                summary="Event", start=datetime(2025, 1, 1), end=datetime(2025, 1, 1, 1)
+            )
+        ]
+
+    monkeypatch.setattr(cp, "load_events", fake_load_events)
+
+    app = FastAPI()
+    app.include_router(cp.router)
+    client = TestClient(app)
+
+    response = client.get("/calendar")
+    assert response.status_code == 200
+    assert "Event" in response.text
+    assert called["args"][0] == date.today()
+    assert called["args"][1] == date.today() + timedelta(days=7)


### PR DESCRIPTION
## Summary
- refresh the `/calendar` page from linked iCal or Google calendars automatically
- document the calendar auto-refresh in the README
- add tests for loading linked calendars

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e57b11a948332af3736b9e8e86f0e