### PR TITLE
Ignore unknown env vars causing config errors

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -10,3 +10,4 @@
 8. **Vault directory** - `parse_projects.parse_all_projects` now creates the vault path and returns an empty list when it doesn't exist.
 9. **Custom task path** - `tasks.write_tasks` ensures the destination directory is created before writing.
 10. **Morning planner tasks** - `index.html` no longer sends the full task list when rendering `morning_planner.txt`, so the backend injects only overdue or soon-due items.
+11. **Unknown environment variables** - `config.py` now ignores extraneous keys like `timezone` to avoid `ValidationError` during startup.

--- a/config.py
+++ b/config.py
@@ -57,6 +57,7 @@ class Config(BaseSettings):  # pylint: disable=too-few-public-methods
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        extra="ignore",  # Ignore unknown keys like system-provided "timezone"
     )
 
     def model_post_init(self, __context):  # type: ignore[override]


### PR DESCRIPTION
## Summary
- ignore extraneous environment variables so system `timezone` entries don't crash startup
- document the fix in `FIXED_BUGS.md`

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e5bbae8d48332be655a21bcc5ccbb