### PR TITLE
Handle directory calendar paths

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -10,3 +10,4 @@
 8. **Vault directory** - `parse_projects.parse_all_projects` now creates the vault path and returns an empty list when it doesn't exist.
 9. **Custom task path** - `tasks.write_tasks` ensures the destination directory is created before writing.
 10. **Morning planner tasks** - `index.html` no longer sends the full task list when rendering `morning_planner.txt`, so the backend injects only overdue or soon-due items.
+11. **Calendar directory crash** - `_read_ics_events` now skips empty paths and reads `.ics` files from directories.

--- a/tests/test_calendar_integration.py
+++ b/tests/test_calendar_integration.py
@@ -53,6 +53,52 @@ END:VCALENDAR""",
     assert ev.start.hour == 14
 
 
+def test_directory_ics_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ics_dir = tmp_path / "cals"
+    ics_dir.mkdir()
+    (ics_dir / "one.ics").write_text(
+        """BEGIN:VCALENDAR
+PRODID:-//Test//EN
+VERSION:2.0
+BEGIN:VEVENT
+UID:1
+DTSTAMP:20250101T120000Z
+DTSTART;TZID=America/New_York:20250101T090000
+DTEND;TZID=America/New_York:20250101T100000
+SUMMARY:Meeting
+END:VEVENT
+END:VCALENDAR""",
+        encoding="utf-8",
+    )
+    (ics_dir / "two.ics").write_text(
+        """BEGIN:VCALENDAR
+PRODID:-//Test//EN
+VERSION:2.0
+BEGIN:VEVENT
+UID:2
+DTSTAMP:20250102T120000Z
+DTSTART;TZID=America/New_York:20250102T090000
+DTEND;TZID=America/New_York:20250102T100000
+SUMMARY:Next Day
+END:VEVENT
+END:VCALENDAR""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("CALENDAR_ICS_PATH", str(ics_dir))
+    monkeypatch.setenv("TIME_ZONE", "UTC")
+
+    import config as cfg
+
+    importlib.reload(cfg)
+    import calendar_integration as ci
+
+    importlib.reload(ci)
+
+    events = ci.load_events(date(2025, 1, 1), date(2025, 1, 2))
+    assert {e.summary for e in events} == {"Meeting", "Next Day"}
+
+
 def test_google_calendar(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("CALENDAR_ICS_PATH", "")
     monkeypatch.setenv("GOOGLE_CALENDAR_ID", "demo")


### PR DESCRIPTION
## Summary
- ignore empty `CALENDAR_ICS_PATH` entries
- read `.ics` files from directories listed in `CALENDAR_ICS_PATH`
- test loading events when `CALENDAR_ICS_PATH` points to a directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5e6832d883328fdf473f513605eb