### PR TITLE
Inject calendar for morning planner

### DIFF
--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -11,4 +11,5 @@
 9. **Custom task path** - `tasks.write_tasks` ensures the destination directory is created before writing.
 10. **Morning planner tasks** - `index.html` no longer sends the full task list when rendering `morning_planner.txt`, so the backend injects only overdue or soon-due items.
 11. **Calendar directory crash** - `_read_ics_events` now skips empty paths and reads `.ics` files from directories.
+12. **Morning planner calendar** - `/render-prompt` now injects today's calendar blocks when rendering `morning_planner.txt` to avoid missing variable errors.
 

--- a/routes/web.py
+++ b/routes/web.py
@@ -14,6 +14,7 @@ from config import config, PROJECT_ROOT
 from prompt_renderer import render_prompt
 from tasks import read_tasks, upcoming_tasks
 from energy import read_entries
+from calendar_integration import load_events
 
 
 router = APIRouter()
@@ -65,8 +66,14 @@ def render_prompt_endpoint(data: dict = Body(...)):
 
     entries = read_entries()
     if is_morning:
-        today = date.today().isoformat()
-        latest = next((e for e in reversed(entries) if e.get("date") == today), {})
+        today = date.today()
+        iso_today = today.isoformat()
+        latest = next((e for e in reversed(entries) if e.get("date") == iso_today), {})
+        events = load_events(today, today)
+        busy_blocks = [
+            f"{ev.start.strftime('%H:%M')}-{ev.end.strftime('%H:%M')}" for ev in events
+        ]
+        variables.setdefault("calendar", busy_blocks)
     else:
         latest = entries[-1] if entries else {}
 

--- a/tests/test_web_route.py
+++ b/tests/test_web_route.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import app
+import routes.web as web
+
+
+class DummyEvent:
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+
+def test_render_prompt_morning_injects_calendar(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(web, "read_tasks", lambda: [])
+    monkeypatch.setattr(web, "upcoming_tasks", lambda: [])
+    monkeypatch.setattr(web, "read_entries", lambda: [])
+    monkeypatch.setattr(
+        web,
+        "load_events",
+        lambda start, end: [
+            DummyEvent(datetime(2023, 1, 1, 9, 0), datetime(2023, 1, 1, 10, 0))
+        ],
+    )
+
+    client = TestClient(app)
+    resp = client.post("/render-prompt", json={"template": "morning_planner.txt"})
+    assert resp.status_code == 200
+    assert "09:00-10:00" in resp.json()["result"]


### PR DESCRIPTION
## Summary
- inject calendar events when rendering `morning_planner.txt` via `/render-prompt`
- document calendar injection fix
- add regression test for morning planner calendar injection

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e6e0601dc833289f78e37075b4b9f