### PR TITLE
Clarify task selection in morning planner

### DIFF
--- a/prompts/morning_planner.txt
+++ b/prompts/morning_planner.txt
@@ -11,8 +11,8 @@ You are a helpful planning assistant. The user is trying to balance sustainable 
 {% endfor %}
 
 **Instructions:**
-- Recommend 1 to 3 tasks for today. Respect the user's available energy and time.
-- Available time blocks may not always be sequential.
+ - Recommend 1 to 3 tasks from the task list above for today. Do not invent tasks that aren't listed. Respect the user's available energy and time.
+ - Available time blocks may not always be sequential.
 - Prioritize urgent or soon-due tasks, but favor ones with lower executive load or activation difficulty.
 - Include at least one “easy win” if possible.
 - Spread tasks across different areas if that supports momentum.


### PR DESCRIPTION
## Summary
- Clarify that morning planner suggestions must come from the provided task list

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e928eb2448332988d59a2f4194251