### PR TITLE
Use GPT-4o-mini for planning with larger responses

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -7,7 +7,11 @@ import openai
 from config import config
 
 
-async def ask_chatgpt(prompt: str, model: str = "gpt-3.5-turbo") -> str:
+async def ask_chatgpt(
+    prompt: str,
+    model: str = "gpt-4o-mini",
+    max_tokens: int = 500,
+) -> str:
     """Send a prompt to OpenAI ChatGPT and return the response text."""
     if not config.OPENAI_API_KEY:
         raise ValueError("OPENAI_API_KEY is not configured")
@@ -16,5 +20,6 @@ async def ask_chatgpt(prompt: str, model: str = "gpt-3.5-turbo") -> str:
         chat_completion = await client.chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
         )
         return chat_completion.choices[0].message.content

--- a/tests/test_openai_route.py
+++ b/tests/test_openai_route.py
@@ -30,14 +30,16 @@ def test_plan_endpoint_intensity(monkeypatch: pytest.MonkeyPatch):
 
     responses = iter(["- Task A", "Plan"])
 
-    async def fake_ask(prompt: str, model: str = "gpt-3.5-turbo"):
+    async def fake_ask(prompt: str, model: str = "gpt-4o-mini", max_tokens: int = 500):
         return next(responses)
 
     captured = []
 
-    async def fake_ask_capture(prompt: str, model: str = "gpt-3.5-turbo"):
+    async def fake_ask_capture(
+        prompt: str, model: str = "gpt-4o-mini", max_tokens: int = 500
+    ):
         captured.append(prompt)
-        return await fake_ask(prompt, model)
+        return await fake_ask(prompt, model, max_tokens)
 
     monkeypatch.setattr(openai_route, "ask_chatgpt", fake_ask_capture)
 


### PR DESCRIPTION
## Summary
- switch `ask_chatgpt` to default to `gpt-4o-mini` and cap responses at 500 tokens to avoid truncation
- adjust tests to reflect new model and token parameters

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black .`
- `pytest tests/test_openai_route.py::test_plan_endpoint_intensity -q`


------
https://chatgpt.com/codex/tasks/task_e_688e9624447c8332b26625b1bb2856a0