### PR TITLE
Add template selection to plan endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,15 +132,18 @@ You can also query ChatGPT from the command line by posting a JSON payload with 
 
 Generate a daily plan using incomplete tasks and today's energy entry. You can
 optionally control how many tasks are recommended by passing an `intensity`
-query parameter (`light`, `medium` or `full`):
+query parameter (`light`, `medium` or `full`) and choose which prompt to run
+with a `template` query parameter (`morning_planner` or
+`plan_intensity_selector`).
 ```bash
-curl -X POST 'http://localhost:8000/plan?intensity=full'
+curl -X POST 'http://localhost:8000/plan?intensity=full&template=morning_planner'
 ```
 The response is stored in `data/morning_plan.yaml` and used to filter
 `/daily-tasks`.
 Tasks with an `energy_cost` higher than your latest logged energy are removed
-before generating the plan. Task selection is performed with the
-`prompts/plan_intensity_selector.txt` template based on the chosen intensity.
+before generating the prompt. Using `template=plan_intensity_selector`
+returns a task selection based on the chosen intensity, while
+`template=morning_planner` produces a complete plan.
 
 Break down a high-level goal into actionable tasks:
 ```bash

--- a/tests/test_openai_route.py
+++ b/tests/test_openai_route.py
@@ -11,7 +11,44 @@ import routes.openai_route as openai_route
 from main import app
 
 
-def test_plan_endpoint_intensity(monkeypatch: pytest.MonkeyPatch):
+def test_plan_endpoint_selector(monkeypatch: pytest.MonkeyPatch):
+    tasks = [
+        {"title": "Task A", "energy_cost": 1},
+        {"title": "Task B", "energy_cost": 2},
+    ]
+
+    monkeypatch.setattr(openai_route, "upcoming_tasks", lambda: tasks)
+    today = date.today().isoformat()
+    monkeypatch.setattr(
+        openai_route,
+        "read_entries",
+        lambda: [{"date": today, "energy": 5, "time_blocks": 4}],
+    )
+    monkeypatch.setattr(openai_route, "filter_tasks_by_energy", lambda t, e: t)
+
+    responses = iter(["- Task A"])
+
+    async def fake_ask(prompt: str, model: str = "gpt-4o-mini", max_tokens: int = 500):
+        return next(responses)
+
+    captured = []
+
+    async def fake_ask_capture(
+        prompt: str, model: str = "gpt-4o-mini", max_tokens: int = 500
+    ):
+        captured.append(prompt)
+        return await fake_ask(prompt, model, max_tokens)
+
+    monkeypatch.setattr(openai_route, "ask_chatgpt", fake_ask_capture)
+
+    client = TestClient(app)
+    resp = client.post("/plan?intensity=light&template=plan_intensity_selector")
+    assert resp.status_code == 200
+    assert resp.json()["plan"] == "- Task A"
+    assert "light" in captured[0]
+
+
+def test_plan_endpoint_morning_planner(monkeypatch: pytest.MonkeyPatch):
     tasks = [
         {"title": "Task A", "energy_cost": 1},
         {"title": "Task B", "energy_cost": 2},
@@ -28,7 +65,7 @@ def test_plan_endpoint_intensity(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(openai_route, "filter_tasks_by_energy", lambda t, e: t)
     monkeypatch.setattr(openai_route, "load_events", lambda s, e: [])
 
-    responses = iter(["- Task A", "Plan"])
+    responses = iter(["Plan"])
 
     async def fake_ask(prompt: str, model: str = "gpt-4o-mini", max_tokens: int = 500):
         return next(responses)
@@ -44,7 +81,7 @@ def test_plan_endpoint_intensity(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(openai_route, "ask_chatgpt", fake_ask_capture)
 
     client = TestClient(app)
-    resp = client.post("/plan?intensity=light")
+    resp = client.post("/plan?template=morning_planner")
     assert resp.status_code == 200
     assert resp.json()["plan"] == "Plan"
-    assert "light" in captured[0]
+    assert "YAML" in captured[0]


### PR DESCRIPTION
## Summary
- allow `/plan` to choose between `plan_intensity_selector` or `morning_planner` templates
- respond with `PlanResponse` model and document new `template` query parameter
- expand tests for both selector and morning planner paths

## Testing
- `black .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f321e57d08332813ccc9975279473