### PR TITLE
Update recurring task due date after completion

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -98,12 +98,18 @@ def mark_tasks_complete(task_ids: List[int], path: Path = TASKS_FILE) -> int:
     if task_ids:
         logger.debug("Task ids to complete: %s", task_ids)
     tasks = read_tasks(path)
-    today = date.today().isoformat()
+    today_date = date.today()
+    today = today_date.isoformat()
     count = 0
     for task in tasks:
         if task.get("id") in task_ids:
             task["status"] = "complete"
             task["last_completed"] = today
+            recurrence = str(task.get("recurrence", "")).lower()
+            days = RECURRENCE_DAYS.get(recurrence)
+            if days:
+                next_due_date = today_date + timedelta(days=days)
+                task["due"] = next_due_date.isoformat()
             count += 1
         task.pop("next_due", None)
         task.pop("due_today", None)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -64,6 +64,27 @@ def test_mark_tasks_complete(tmp_path: Path):
     assert updated[0]["last_completed"] == date.today().isoformat()
 
 
+def test_mark_recurring_task_updates_due(tmp_path: Path):
+    """Completing a recurring task should advance its due date."""
+    path = tmp_path / "tasks.yaml"
+    today = date.today()
+    tasks = [
+        {
+            "id": 1,
+            "title": "habit",
+            "status": "active",
+            "recurrence": "daily",
+            "due": today.isoformat(),
+        }
+    ]
+    write_tasks(tasks, path)
+    mark_tasks_complete([1], path)
+    updated = read_tasks(path)
+    expected_due = (today + timedelta(days=1)).isoformat()
+    assert updated[0]["due"] == expected_due
+    assert updated[0]["next_due"] == expected_due
+
+
 def test_due_date_flag(tmp_path: Path):
     """Tasks with a due date should set due_today accordingly."""
     target = tmp_path / "tasks.yaml"


### PR DESCRIPTION
## Summary
- update recurring task completion logic to advance the due date based on its frequency
- add coverage ensuring recurring task due dates move forward after marking complete

## Testing
- pytest tests/test_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68fd5cd25a4c8332ba143a22e7eb9665